### PR TITLE
Fix override operator image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@ IMG_REGISTRY ?= "quay.io"
 IMG_ORG ?= "opendatahub"
 IMG_REPO ?= "model-registry-operator"
 IMG_VERSION ?= "latest"
-IMG ?= "${IMG_REGISTRY}/${IMG_ORG}/${IMG_REPO}:${IMG_VERSION}"
+IMG_REPOSITORY ?= "${IMG_REGISTRY}/${IMG_ORG}/${IMG_REPO}"
+IMG ?= "${IMG_REPOSITORY}:${IMG_VERSION}"
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.28.0
 
@@ -126,7 +127,7 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
+	cd config/manager && $(KUSTOMIZE) edit set image ${IMG_REPOSITORY}=${IMG}
 	$(KUSTOMIZE) build config/default | $(KUBECTL) apply -f -
 
 .PHONY: undeploy

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -3,6 +3,6 @@ resources:
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
-- name: controller
+- name: quay.io/opendatahub/model-registry-operator
   newName: quay.io/opendatahub/model-registry-operator
   newTag: latest


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes https://github.com/opendatahub-io/model-registry-operator/issues/24

## Description
Makes the operator image correcly overridable using `make deploy IMG=<...>` script.

The issue is here: `$(KUSTOMIZE) edit set image controller=${IMG}` where `controller` is not the actual image in `manager.yaml`, and as per my understanding the kustomize edit should have the following structure:
```
$(KUSTOMIZE) edit set image ${CURRENT_IMG}=${NEW_IMG}:${NEW_TAG}
```
Therefore replacing `controller` with the actual image `quay.io/opendatahub/model-registry-operator` should do the trick.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Run `make deploy IMG=quay.io/opendatahub/model-registry-operator:main-4c04ff7`
2. Describe the operator pod: `k describe pod/model-registry-operator-controller-manager-<...> -n model-registry-operator-system`
3. `  Normal  Pulling    56s   kubelet            Pulling image "quay.io/opendatahub/model-registry-operator:main-4c04ff7"`

Alternatively:
1. Run `cd config/manager && kustomize edit set image quay.io/opendatahub/model-registry-operator=quay.io/opendatahub/model-registry-operator:main-4c04ff7`
2. `config/manager/kustomization.yaml` should contain the following changes:
```yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
- name: quay.io/opendatahub/model-registry-operator
  newName: quay.io/opendatahub/model-registry-operator
  newTag: main-4c04ff7
```
4. Issue `kustomize build .` or `kustomize build config/manager` depending if you are in the target directory or in the root.
5. Check the generated output contains `:main-4c04ff7` version of the operator image:
```yaml
...
          value: "false"
        image: quay.io/opendatahub/model-registry-operator:main-4c04ff7
        livenessProbe:
          httpGet:
            path: /healthz
            port: 8081
...
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
