### PR TITLE
Explicit model-registry proxy MLMD gRPC port param

### DIFF
--- a/internal/controller/config/templates/deployment.yaml.tmpl
+++ b/internal/controller/config/templates/deployment.yaml.tmpl
@@ -79,8 +79,8 @@ spec:
         - args:
             - --hostname=0.0.0.0
             - --port={{.Spec.Rest.Port}}
-            #- --mlmd-hostname=localhost
-            #- --mlmd-port={{.Spec.Grpc.Port}}
+            - --mlmd-hostname=localhost
+            - --mlmd-port={{.Spec.Grpc.Port}}
           command:
             - /model-registry
             - proxy


### PR DESCRIPTION
Resolves #26

## Description
Without explicit params the deployed MR would try to connect to MLMD gRPC to localhost:8081
See: https://github.com/opendatahub-io/model-registry/blob/04aa36605d43a9884b06fb9cd68ce46a14b6b717/cmd/proxy.go#L77-L80

### AFTER
Now connects to port 9090 accounting for template values:

## How Has This Been Tested?
Ad-hoc built operator in another quay organization and deployed with this change.
Deploys as expected:

<img width="1840" alt="Screenshot 2023-11-13 at 11 16 24" src="https://github.com/opendatahub-io/model-registry-operator/assets/1699252/21029c76-2ea3-4796-bf5c-2030ef58130b">

<img width="1840" alt="Screenshot 2023-11-13 at 11 16 40" src="https://github.com/opendatahub-io/model-registry-operator/assets/1699252/74ab7f66-8790-41f2-9915-328e269d176f">

NOTE: notice the `I1113 10:05:11.181255 1 proxy.go:34] MLMD server localhost:9090` line, to connect to the expected defaults.

Manually created OCP Route (accounting for #19 by defining it manually):
<img width="1269" alt="Screenshot 2023-11-13 at 11 29 46" src="https://github.com/opendatahub-io/model-registry-operator/assets/1699252/8201db92-e1a0-425f-9a3f-222cf50626f0">

Then can be used:
<img width="1387" alt="Screenshot 2023-11-13 at 11 17 48" src="https://github.com/opendatahub-io/model-registry-operator/assets/1699252/8972cd94-1db1-4686-8c36-84601a8653ea">



## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
