### PR TITLE
Add support for creating a Route for ModelRegistry http REST service, fixes #19

### DIFF
--- a/api/v1alpha1/modelregistry_types.go
+++ b/api/v1alpha1/modelregistry_types.go
@@ -93,6 +93,11 @@ type RestSpec struct {
 	// Listen port for REST connections, defaults to 8080.
 	Port *int32 `json:"port,omitempty"`
 
+	//+kubebuilder:validation:Enum=disabled;enabled
+	//+kubebuilder:default=disabled
+	// Create an OpenShift Route for REST Service
+	ServiceRoute string `json:"serviceRoute,omitempty"`
+
 	// Resource requirements
 	//+optional
 	Resources *v1.ResourceRequirements `json:"resources,omitempty"`

--- a/api/v1alpha1/modelregistry_webhook.go
+++ b/api/v1alpha1/modelregistry_webhook.go
@@ -51,6 +51,10 @@ func (r *ModelRegistry) Default() {
 	if len(r.Spec.Grpc.Image) == 0 {
 		r.Spec.Grpc.Image = config.GetStringConfigWithDefault(config.GrpcImage, config.DefaultGrpcImage)
 	}
+
+	if len(r.Spec.Rest.ServiceRoute) == 0 {
+		r.Spec.Rest.ServiceRoute = config.RouteDisabled
+	}
 	if r.Spec.Rest.Resources == nil {
 		r.Spec.Rest.Resources = config.MlmdRestResourceRequirements.DeepCopy()
 	}

--- a/config/crd/bases/modelregistry.opendatahub.io_modelregistries.yaml
+++ b/config/crd/bases/modelregistry.opendatahub.io_modelregistries.yaml
@@ -249,6 +249,13 @@ spec:
                           Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
                     type: object
+                  serviceRoute:
+                    default: disabled
+                    description: Create an OpenShift Route for REST Service
+                    enum:
+                    - disabled
+                    - enabled
+                    type: string
                 type: object
             required:
             - grpc

--- a/config/samples/modelregistry_v1alpha1_modelregistry.yaml
+++ b/config/samples/modelregistry_v1alpha1_modelregistry.yaml
@@ -14,6 +14,7 @@ spec:
     port: 9090
   rest:
     port: 8080
+    serviceRoute: disabled
   postgres:
     host: model-registry-db
     database: model-registry

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/go-logr/logr v1.3.0
 	github.com/onsi/ginkgo/v2 v2.13.1
 	github.com/onsi/gomega v1.30.0
+	github.com/openshift/api v0.0.0-20231116201359-a5824a0c15b6
 	github.com/spf13/viper v1.17.0
 	k8s.io/api v0.28.3
 	k8s.io/apimachinery v0.28.3

--- a/go.sum
+++ b/go.sum
@@ -246,6 +246,8 @@ github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGV
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.30.0 h1:hvMK7xYz4D3HapigLTeGdId/NcfQx1VHMJc60ew99+8=
 github.com/onsi/gomega v1.30.0/go.mod h1:9sxs+SwGrKI0+PWe4Fxa9tFQQBG5xSsSbMXOI8PPpoQ=
+github.com/openshift/api v0.0.0-20231116201359-a5824a0c15b6 h1:4RuImZKF08UNKj3vt77jPLDdWIKOXudGhPSV25Vwca8=
+github.com/openshift/api v0.0.0-20231116201359-a5824a0c15b6/go.mod h1:qNtV0315F+f8ld52TLtPvrfivZpdimOzTi3kn9IVbtU=
 github.com/pelletier/go-toml/v2 v2.1.0 h1:FnwAJ4oYMvbT/34k9zzHuZNrhlz48GB3/s6at6/MHO4=
 github.com/pelletier/go-toml/v2 v2.1.0/go.mod h1:tJU2Z3ZkXwnxa4DPO899bsyIoywizdUvyaeZurnPPDc=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/internal/controller/config/defaults.go
+++ b/internal/controller/config/defaults.go
@@ -32,6 +32,8 @@ const (
 	RestImage        = "REST_IMAGE"
 	DefaultGrpcImage = "gcr.io/tfx-oss-public/ml_metadata_store_server:1.14.0"
 	DefaultRestImage = "quay.io/opendatahub/model-registry:latest"
+	RouteDisabled    = "disabled"
+	RouteEnabled     = "enabled"
 )
 
 // Default ResourceRequirements

--- a/internal/controller/config/templates/http-route.yaml.tmpl
+++ b/internal/controller/config/templates/http-route.yaml.tmpl
@@ -1,0 +1,14 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{.Name}}-http
+  namespace: {{.Namespace}}
+  labels:
+    app: {{.Name}}
+    component: model-registry
+spec:
+  to:
+    kind: Service
+    name: {{.Name}}
+  port:
+    targetPort: http-api

--- a/internal/controller/modelregistry_controller_test.go
+++ b/internal/controller/modelregistry_controller_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/opendatahub-io/model-registry-operator/internal/controller/config"
+	"github.com/openshift/api"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/client-go/tools/record"
 	"os"
@@ -135,9 +136,11 @@ var _ = Describe("ModelRegistry controller", func() {
 				return k8sClient.Get(ctx, typeNamespaceName, found)
 			}, time.Minute, time.Second).Should(Succeed())
 
+			scheme := k8sClient.Scheme()
+			_ = api.Install(scheme)
 			modelRegistryReconciler := &ModelRegistryReconciler{
 				Client:   k8sClient,
-				Scheme:   k8sClient.Scheme(),
+				Scheme:   scheme,
 				Recorder: &record.FakeRecorder{},
 				Log:      ctrl.Log.WithName("controller"),
 				Template: template,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added template and logic to create an OpenShift Route only if the controller is running in an OpenShift cluster. 
Fixes #19

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested by setting the rest spec flag `ServiceRoute` to enabled in sample model registry manually to verify that Route is created.
Tested Route by using curl against the hostname created by OpenShift.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work