### PR TITLE
chore: Add kind integration test, fixes #41

### DIFF
--- a/.github/workflows/build-image-pr.yml
+++ b/.github/workflows/build-image-pr.yml
@@ -1,7 +1,7 @@
 name: Test controller image build and deployment
 
 on:
-  pull_request_target:
+  pull_request:
     paths-ignore:
       - 'LICENSE*'
       - '**.gitignore'

--- a/.github/workflows/build-image-pr.yml
+++ b/.github/workflows/build-image-pr.yml
@@ -1,4 +1,4 @@
-name: Test controller image build
+name: Test controller image build and deployment
 
 on:
   pull_request_target:
@@ -16,10 +16,14 @@ env:
   PUSH_IMAGE: false
 
 jobs:
-  build-image:
+  build-and-test-image:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.20.10'
       - name: Generate Tag
         shell: bash
         id: tags
@@ -30,5 +34,35 @@ jobs:
       - name: Build Image
         shell: bash
         env:
-          VERSION: ${{ steps.tags.outputs.tag }}
-        run: ./scripts/build_deploy.sh
+          IMG_VERSION: ${{ steps.tags.outputs.tag }}
+          IMG: "model-registry-operator:${{ steps.tags.outputs.tag }}"
+        run: |
+          make docker-build
+      - name: Start Kind Cluster
+        uses: helm/kind-action@v1.4.0
+      - name: Load Local Test Image
+        env:
+          IMG_VERSION: ${{ steps.tags.outputs.tag }}
+          IMG: "model-registry-operator:${{ steps.tags.outputs.tag }}"
+        run: |
+          kind load docker-image -n chart-testing ${IMG}
+      - name: Deploy Operator Image
+        env:
+          IMG_VERSION: ${{ steps.tags.outputs.tag }}
+          IMG: "model-registry-operator:${{ steps.tags.outputs.tag }}"
+        run: |
+          make deploy
+      - name: Create Test Registry
+        run: |
+          kubectl apply -k config/samples/
+          kubectl get mr
+      - name: Wait for Test Registry Deployment
+        timeout-minutes: 5
+        run: |
+          CONDITION="false"
+          while [ "${CONDITION}" != "True" ]
+          do
+            sleep 5
+            CONDITION="`kubectl get mr modelregistry-sample --output=jsonpath='{.status.conditions[?(@.type=="Available")].status}'`"
+            echo "Registry Available=${CONDITION}"
+          done

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ docker-build: ## Build docker image with the manager.
 docker-push: ## Push docker image with the manager.
 	$(CONTAINER_TOOL) push ${IMG}
 
-.PHONY: docker-push
+.PHONY: docker-login
 docker-login: ## Login to docker registry.
 	$(CONTAINER_TOOL) login -u "${DOCKER_USER}" -p "${DOCKER_PWD}" "${IMG_REGISTRY}"
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added kind integration test to build-image-pr.yaml workflow.
It creates a Kind cluster, deploys operator image built for the PR in the test cluster, and checks that it can create a model registry from sample model registry CR.
Fixes #41

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested GH action locally using [act](https://github.com/nektos/act). 

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work