### PR TITLE
[RHOAIENG-2267] Use ubi8 base images for Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.21 as builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.20.10 as builder
 ARG TARGETOS
 ARG TARGETARCH
 
@@ -25,7 +25,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o ma
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes https://issues.redhat.com/browse/RHOAIENG-2267

## Description
<!--- Describe your changes in detail -->

Rely on UBI base images for the container image generation as other operators/controllers are doing, e.g., [opendatahub-operator](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/Dockerfiles/Dockerfile) or [odh-model-controller](https://github.com/opendatahub-io/odh-model-controller/blob/main/Containerfile).

Note that this change is required for production builds, therefore I would keep the differences as small as possible.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested locally by running:
```bash
docker build -t model-registry-operator:latest -f Dockerfile .
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
