### PR TITLE
fix: init viper to use env variables, fixes #RHOAIENG-3427

### DIFF
--- a/internal/controller/config/defaults.go
+++ b/internal/controller/config/defaults.go
@@ -42,6 +42,11 @@ var (
 	MlmdGRPCResourceRequirements = createResourceRequirement(resource.MustParse("100m"), resource.MustParse("256Mi"), resource.MustParse("100m"), resource.MustParse("256Mi"))
 )
 
+func init() {
+	// init viper for config env variables
+	viper.AutomaticEnv()
+}
+
 func createResourceRequirement(RequestsCPU resource.Quantity, RequestsMemory resource.Quantity, LimitsCPU resource.Quantity, LimitsMemory resource.Quantity) v1.ResourceRequirements {
 	return v1.ResourceRequirements{
 		Requests: v1.ResourceList{

--- a/internal/controller/config/defaults_test.go
+++ b/internal/controller/config/defaults_test.go
@@ -1,0 +1,25 @@
+package config
+
+import (
+	"os"
+	"testing"
+)
+
+func TestGetStringConfigWithDefault(t *testing.T) {
+	tests := []struct {
+		name       string
+		configName string
+		want       string
+	}{
+		{name: "test " + GrpcImage, configName: GrpcImage, want: "success1"},
+		{name: "test " + RestImage, configName: RestImage, want: "success2"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			os.Setenv(tt.configName, tt.want)
+			if got := GetStringConfigWithDefault(tt.configName, "fail"); got != tt.want {
+				t.Errorf("GetStringConfigWithDefault() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/controller/modelregistry_controller_test.go
+++ b/internal/controller/modelregistry_controller_test.go
@@ -41,6 +41,7 @@ import (
 )
 
 var _ = Describe("ModelRegistry controller", func() {
+
 	Context("ModelRegistry controller test", func() {
 
 		ctx := context.Background()
@@ -58,9 +59,9 @@ var _ = Describe("ModelRegistry controller", func() {
 
 			BeforeEach(func() {
 				By("Setting the Image ENV VARs which stores the Server images")
-				err = os.Setenv("GRPC_IMAGE", config.DefaultGrpcImage)
+				err = os.Setenv(config.GrpcImage, config.DefaultGrpcImage)
 				Expect(err).To(Not(HaveOccurred()))
-				err = os.Setenv("REST_IMAGE", config.DefaultRestImage)
+				err = os.Setenv(config.RestImage, config.DefaultRestImage)
 				Expect(err).To(Not(HaveOccurred()))
 			})
 
@@ -167,8 +168,8 @@ var _ = Describe("ModelRegistry controller", func() {
 				_ = k8sClient.Delete(ctx, namespace)
 
 				By("Removing the Image ENV VARs which stores the Server images")
-				_ = os.Unsetenv("GRPC_IMAGE")
-				_ = os.Unsetenv("REST_IMAGE")
+				_ = os.Unsetenv(config.GrpcImage)
+				_ = os.Unsetenv(config.RestImage)
 			})
 		})
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added viper.AutomaticEnv() in defaults.go init() to use env variables
Fixes #RHOAIENG-3427

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added unit test to verify GetStringConfigWithDefault uses env variables.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work