### PR TITLE
chore: change release image versions to v0.1.2

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -76,7 +76,7 @@ spec:
           - name: GRPC_IMAGE
             value: gcr.io/tfx-oss-public/ml_metadata_store_server:1.14.0
           - name: REST_IMAGE
-            value: quay.io/opendatahub/model-registry:latest
+            value: quay.io/opendatahub/model-registry:v0.1.2
           - name: ENABLE_WEBHOOKS
             value: "false"
         securityContext:

--- a/config/overlays/odh/params.env
+++ b/config/overlays/odh/params.env
@@ -1,3 +1,3 @@
-IMAGES_MODELREGISTRY_OPERATOR=quay.io/opendatahub/model-registry-operator:latest
+IMAGES_MODELREGISTRY_OPERATOR=quay.io/opendatahub/model-registry-operator:v0.1.2
 IMAGES_GRPC_SERVICE=gcr.io/tfx-oss-public/ml_metadata_store_server:1.14.0
-IMAGES_REST_SERVICE=quay.io/opendatahub/model-registry:latest
+IMAGES_REST_SERVICE=quay.io/opendatahub/model-registry:v0.1.2

--- a/internal/controller/config/defaults.go
+++ b/internal/controller/config/defaults.go
@@ -18,10 +18,11 @@ package config
 
 import (
 	"embed"
+	"text/template"
+
 	"github.com/spf13/viper"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"text/template"
 )
 
 //go:embed templates/*.yaml.tmpl
@@ -31,7 +32,7 @@ const (
 	GrpcImage        = "GRPC_IMAGE"
 	RestImage        = "REST_IMAGE"
 	DefaultGrpcImage = "gcr.io/tfx-oss-public/ml_metadata_store_server:1.14.0"
-	DefaultRestImage = "quay.io/opendatahub/model-registry:latest"
+	DefaultRestImage = "quay.io/opendatahub/model-registry:v0.1.2"
 	RouteDisabled    = "disabled"
 	RouteEnabled     = "enabled"
 )


### PR DESCRIPTION
Create a new model-registry-operator release updating to MR v0.1.2,
mimics https://github.com/opendatahub-io/model-registry-operator/pull/55, https://github.com/opendatahub-io/model-registry-operator/pull/62

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
