### PR TITLE
fix: disable Istio injection in deployment for non-istio model registries, fixes RHOAIENG-5154

### DIFF
--- a/internal/controller/config/templates/deployment.yaml.tmpl
+++ b/internal/controller/config/templates/deployment.yaml.tmpl
@@ -24,7 +24,7 @@ spec:
       labels:
         app: {{.Name}}
         component: model-registry
-        sidecar.istio.io/inject: "true"
+        sidecar.istio.io/inject: {{with .Spec.Istio}}"true"{{else}}"false"{{end}}
       annotations:
         {{- if .Spec.Postgres}}
         traffic.sidecar.istio.io/excludeOutboundPorts: {{.Spec.Postgres.Port}}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Disable Istio injection in deployment for non-istio model registries by setting label `sidecar.istio.io/inject` to `false`
Fixes RHOAIENG-5154

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested by creating a non-istio model registry in an istio servicemeshmember namespace. 

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work