### PR TITLE
fix: delete istio resources when istio is disabled, fixes RHOAIENG-5158

### DIFF
--- a/internal/controller/modelregistry_controller.go
+++ b/internal/controller/modelregistry_controller.go
@@ -330,21 +330,23 @@ func (r *ModelRegistryReconciler) updateRegistryResources(ctx context.Context, p
 		}
 	}
 
-	if registry.Spec.Istio != nil {
-		result2, err = r.createOrUpdateIstioConfig(ctx, params, registry)
-		if err != nil {
-			return result2, err
-		}
-		if result2 != ResourceUnchanged {
-			result = result2
-		}
-	} else {
-		result2, err = r.deleteIstioConfig(ctx, params)
-		if err != nil {
-			return result2, err
-		}
-		if result2 != ResourceUnchanged {
-			result = result2
+	if r.HasIstio {
+		if registry.Spec.Istio != nil {
+			result2, err = r.createOrUpdateIstioConfig(ctx, params, registry)
+			if err != nil {
+				return result2, err
+			}
+			if result2 != ResourceUnchanged {
+				result = result2
+			}
+		} else {
+			result2, err = r.deleteIstioConfig(ctx, params)
+			if err != nil {
+				return result2, err
+			}
+			if result2 != ResourceUnchanged {
+				result = result2
+			}
 		}
 	}
 

--- a/internal/controller/modelregistry_controller.go
+++ b/internal/controller/modelregistry_controller.go
@@ -338,6 +338,14 @@ func (r *ModelRegistryReconciler) updateRegistryResources(ctx context.Context, p
 		if result2 != ResourceUnchanged {
 			result = result2
 		}
+	} else {
+		result2, err = r.deleteIstioConfig(ctx, params)
+		if err != nil {
+			return result2, err
+		}
+		if result2 != ResourceUnchanged {
+			result = result2
+		}
 	}
 
 	return result, nil
@@ -458,6 +466,39 @@ func (r *ModelRegistryReconciler) createOrUpdateIstioConfig(ctx context.Context,
 	}
 
 	return result, nil
+}
+
+func (r *ModelRegistryReconciler) deleteIstioConfig(ctx context.Context, params *ModelRegistryParams) (OperationResult, error) {
+	var err error
+
+	objectMeta := metav1.ObjectMeta{Name: params.Name, Namespace: params.Namespace}
+	virtualService := networking.VirtualService{ObjectMeta: objectMeta}
+	if err = r.Client.Delete(ctx, &virtualService); client.IgnoreNotFound(err) != nil {
+		return ResourceUpdated, err
+	}
+
+	destinationRule := networking.DestinationRule{ObjectMeta: objectMeta}
+	if err = r.Client.Delete(ctx, &destinationRule); client.IgnoreNotFound(err) != nil {
+		return ResourceUpdated, err
+	}
+
+	authorizationPolicy := security.AuthorizationPolicy{ObjectMeta: objectMeta}
+	authorizationPolicy.Name = authorizationPolicy.Name + "-authorino"
+	if err = r.Client.Delete(ctx, &authorizationPolicy); client.IgnoreNotFound(err) != nil {
+		return ResourceUpdated, err
+	}
+
+	authConfig := authorino.AuthConfig{ObjectMeta: objectMeta}
+	if err = r.Client.Delete(ctx, &authConfig); client.IgnoreNotFound(err) != nil {
+		return ResourceUpdated, err
+	}
+
+	gateway := networking.Gateway{ObjectMeta: objectMeta}
+	if err = r.Client.Delete(ctx, &gateway); client.IgnoreNotFound(err) != nil {
+		return ResourceUpdated, err
+	}
+
+	return ResourceUnchanged, nil
 }
 
 func (r *ModelRegistryReconciler) createOrUpdateGateway(ctx context.Context, params *ModelRegistryParams,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When istio config is missing, delete all istio resources
Fixes RHOAIENG-5158

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work