### PR TITLE
updated workflow to push multi-arch image for s390x

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -20,7 +20,6 @@ env:
   QUAY_IMG_REPO: model-registry-operator
   QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
   QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
-  PUSH_IMAGE: true
 
 jobs:
   build-image:
@@ -36,36 +35,35 @@ jobs:
       # checkout branch
       - uses: actions/checkout@v4
       # set image version
-      - name: Set main-branch environment
-        if: env.BUILD_CONTEXT == 'main'
-        run: |
-          commit_sha=${{ github.event.after }}
-          tag=main-${commit_sha:0:7}
-          echo "VERSION=${tag}" >> $GITHUB_ENV
       - name: Set tag environment
         if: env.BUILD_CONTEXT == 'tag'
         run: |
           echo "VERSION=${{ github.ref_name }}" >> $GITHUB_ENV
-      - name: Build and Push Image
-        shell: bash
-        run: ./scripts/build_deploy.sh
-      - name: Tag Latest
+      - name: Set main branch environment
         if: env.BUILD_CONTEXT == 'main'
-        shell: bash
-        env:
-          IMG: quay.io/${{ env.QUAY_ORG }}/${{ env.QUAY_IMG_REPO }}
-          BUILD_IMAGE: false
         run: |
-          docker tag ${{ env.IMG }}:$VERSION ${{ env.IMG }}:latest
-          # BUILD_IMAGE=false skip the build
-          ./scripts/build_deploy.sh
-      - name: Tag Main
+          echo "TAG=latest" >> $GITHUB_ENV
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to Quay.io
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+      - name: Build and Push Image 
+        if: env.BUILD_CONTEXT == 'tag'
+        uses: docker/build-push-action@v3
+        with:
+          tags: quay.io/${{ env.QUAY_ORG }}/${{ env.QUAY_IMG_REPO }}:${{ env.VERSION }}
+          platforms: linux/amd64,linux/s390x,linux/ppc64le
+          push: true
+      - name: Build and Push Latest tag
         if: env.BUILD_CONTEXT == 'main'
-        shell: bash
-        env:
-          IMG: quay.io/${{ env.QUAY_ORG }}/${{ env.QUAY_IMG_REPO }}
-          BUILD_IMAGE: false
-        run: |
-          docker tag ${{ env.IMG }}:$VERSION ${{ env.IMG }}:main
-          # BUILD_IMAGE=false skip the build
-          ./scripts/build_deploy.sh
+        uses: docker/build-push-action@v3
+        with:
+          tags: quay.io/${{ env.QUAY_ORG }}/${{ env.QUAY_IMG_REPO }}:${{ env.TAG }}
+          platforms: linux/amd64,linux/s390x,linux/ppc64le
+          push: true


### PR DESCRIPTION

## Description
Updated build and push github workflow with qemu action to build & push multi-arch image

## How Has This Been Tested?
Workflow has been executed and able to push multi-arch image on local registry
Tested on local environment by deploying in local environment


```
[root@m1305001 model-registry-operator]# make deploy IMG=quay.io/morana/opendatahub/model-registry-operator:latest
test -s /root/model-registry-operator/bin/controller-gen && /root/model-registry-operator/bin/controller-gen --version | grep -q v0.13.0 || \
GOBIN=/root/model-registry-operator/bin go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.13.0
/root/model-registry-operator/bin/controller-gen rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
test -s /root/model-registry-operator/bin/kustomize || GOBIN=/root/model-registry-operator/bin GO111MODULE=on go install sigs.k8s.io/kustomize/kustomize/v5@v5.1.1
cd config/manager && /root/model-registry-operator/bin/kustomize edit set image controller=quay.io/morana/opendatahub/model-registry-operator:latest
/root/model-registry-operator/bin/kustomize build config/"default" | kubectl apply -f -
namespace/model-registry-operator-system unchanged
customresourcedefinition.apiextensions.k8s.io/modelregistries.modelregistry.opendatahub.io configured
serviceaccount/model-registry-operator-controller-manager unchanged
role.rbac.authorization.k8s.io/model-registry-operator-leader-election-role unchanged
clusterrole.rbac.authorization.k8s.io/model-registry-operator-manager-role configured
clusterrole.rbac.authorization.k8s.io/model-registry-operator-metrics-reader unchanged
clusterrole.rbac.authorization.k8s.io/model-registry-operator-proxy-role unchanged
rolebinding.rbac.authorization.k8s.io/model-registry-operator-leader-election-rolebinding unchanged
clusterrolebinding.rbac.authorization.k8s.io/model-registry-operator-manager-rolebinding unchanged
clusterrolebinding.rbac.authorization.k8s.io/model-registry-operator-proxy-rolebinding unchanged
service/model-registry-operator-controller-manager-metrics-service unchanged
deployment.apps/model-registry-operator-controller-manager configured

[root@m1305001 model-registry-operator]# oc get all -n model-registry-operator-system
Warning: apps.openshift.io/v1 DeploymentConfig is deprecated in v4.14+, unavailable in v4.10000+
NAME                                                              READY   STATUS             RESTARTS   AGE
pod/model-registry-operator-controller-manager-556c8646df-r7t9q   2/2     Running            0          18d
pod/model-registry-operator-controller-manager-84c94c48c8-5hff9   2/2     Running   0          110s

NAME                                                                 TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)    AGE
service/model-registry-operator-controller-manager-metrics-service   ClusterIP   172.30.240.33   <none>        8443/TCP   18d

NAME                                                         READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/model-registry-operator-controller-manager   1/1     1            1           18d

NAME                                                                    DESIRED   CURRENT   READY   AGE
replicaset.apps/model-registry-operator-controller-manager-556c8646df   1         1         1       18d
replicaset.apps/model-registry-operator-controller-manager-84c94c48c8   1         1         0       110s
```