### PR TITLE
fix: create gateway service routes in model registry operator, fixes RHOAIENG-5559

### DIFF
--- a/api/v1alpha1/modelregistry_types.go
+++ b/api/v1alpha1/modelregistry_types.go
@@ -215,6 +215,12 @@ type ServerConfig struct {
 	// https, and the TLS modes to use.
 	//+optional
 	TLS *TLSServerSettings `json:"tls,omitempty"`
+
+	//+kubebuilder:default:enabled
+	//+kubebuilder:validation:Enum=disabled;enabled
+
+	// Creates an OpenShift Route for Gateway Service when set to enabled (default).
+	GatewayRoute string `json:"gatewayRoute,omitempty"`
 }
 
 type GatewayConfig struct {

--- a/api/v1alpha1/modelregistry_webhook.go
+++ b/api/v1alpha1/modelregistry_webhook.go
@@ -109,6 +109,13 @@ func (r *ModelRegistry) Default() {
 					r.Spec.Istio.Gateway.Grpc.Port = &httpPort
 				}
 			}
+			// enable gateway routes by default
+			if len(r.Spec.Istio.Gateway.Rest.GatewayRoute) == 0 {
+				r.Spec.Istio.Gateway.Rest.GatewayRoute = config.RouteEnabled
+			}
+			if len(r.Spec.Istio.Gateway.Grpc.GatewayRoute) == 0 {
+				r.Spec.Istio.Gateway.Grpc.GatewayRoute = config.RouteEnabled
+			}
 		}
 	}
 }

--- a/config/crd/bases/modelregistry.opendatahub.io_modelregistries.yaml
+++ b/config/crd/bases/modelregistry.opendatahub.io_modelregistries.yaml
@@ -143,6 +143,13 @@ spec:
                       grpc:
                         description: gRPC  gateway server config
                         properties:
+                          gatewayRoute:
+                            description: Creates an OpenShift Route for Gateway Service
+                              when set to enabled (default).
+                            enum:
+                            - disabled
+                            - enabled
+                            type: string
                           port:
                             description: Listen port for server connections, defaults
                               to 80 without TLS and 443 when TLS settings are present.
@@ -215,6 +222,13 @@ spec:
                       rest:
                         description: Rest gateway server config
                         properties:
+                          gatewayRoute:
+                            description: Creates an OpenShift Route for Gateway Service
+                              when set to enabled (default).
+                            enum:
+                            - disabled
+                            - enabled
+                            type: string
                           port:
                             description: Listen port for server connections, defaults
                               to 80 without TLS and 443 when TLS settings are present.

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -155,6 +155,18 @@ rules:
   - update
   - watch
 - apiGroups:
+  - route.openshift.io
+  resources:
+  - routes/custom-host
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - security.istio.io
   resources:
   - authorizationpolicies

--- a/config/samples/istio/components/istio_modelregistry.yaml
+++ b/config/samples/istio/components/istio_modelregistry.yaml
@@ -9,5 +9,7 @@ spec:
     gateway:
       domain: DOMAIN
       istioIngress: ISTIO_INGRESS
-      rest: {}
-      grpc: {}
+      rest:
+        gatewayRoute: enabled
+      grpc:
+        gatewayRoute: enabled

--- a/internal/controller/config/templates/istio/gateway-route.yaml.tmpl
+++ b/internal/controller/config/templates/istio/gateway-route.yaml.tmpl
@@ -1,0 +1,31 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  annotations:
+    maistra.io/original-host: {{.Host}}.{{.Spec.Istio.Gateway.Domain}}
+  labels:
+    app: {{.Name}}
+    component: model-registry
+    app.kubernetes.io/name: {{.Name}}
+    app.kubernetes.io/instance: {{.Name}}
+    app.kubernetes.io/component: model-registry
+    app.kubernetes.io/created-by: model-registry-operator
+    app.kubernetes.io/part-of: model-registry
+    app.kubernetes.io/managed-by: model-registry-operator
+    maistra.io/gateway-name: {{.Name}}
+    maistra.io/gateway-namespace: {{.Namespace}}
+  name: {{.Namespace}}-{{.Host}}
+  namespace: {{.IngressService.Namespace}}
+spec:
+  host: {{.Host}}.{{.Spec.Istio.Gateway.Domain}}
+  port:
+    targetPort: {{with .TLS}}https{{else}}http2{{end}}
+  {{- with .TLS}}
+  tls:
+    termination: passthrough
+  {{- end}}
+  to:
+    kind: Service
+    name: {{.IngressService.Name}}
+    weight: 100
+  wildcardPolicy: None

--- a/internal/controller/modelregistry_controller.go
+++ b/internal/controller/modelregistry_controller.go
@@ -263,6 +263,7 @@ func (r *ModelRegistryReconciler) SetupWithManager(mgr ctrl.Manager) error {
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=services;serviceaccounts,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=route.openshift.io,resources=routes/custom-host,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=user.openshift.io,resources=groups,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;create;update;patch;delete

--- a/internal/controller/modelregistry_controller.go
+++ b/internal/controller/modelregistry_controller.go
@@ -143,7 +143,10 @@ func (r *ModelRegistryReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 			// Perform all operations required before remove the finalizer and allow
 			// the Kubernetes API to remove the custom resource.
-			r.doFinalizerOperationsForModelRegistry(modelRegistry)
+			if err = r.doFinalizerOperationsForModelRegistry(ctx, modelRegistry); err != nil {
+				log.Error(err, "Failed to do finalizer operations for modelRegistry")
+				return ctrl.Result{Requeue: true}, nil
+			}
 
 			// TODO(user): If you add operations to the doFinalizerOperationsForModelRegistry method
 			// then you need to ensure that all worked fine before deleting and updating the Downgrade status
@@ -467,6 +470,16 @@ func (r *ModelRegistryReconciler) createOrUpdateIstioConfig(ctx context.Context,
 		if result2 != ResourceUnchanged {
 			result = result2
 		}
+
+		if r.IsOpenShift {
+			result2, err = r.createOrUpdateGatewayRoutes(ctx, params, registry, "gateway-route.yaml.tmpl")
+			if err != nil {
+				return result2, err
+			}
+			if result2 != ResourceUnchanged {
+				result = result2
+			}
+		}
 	} else {
 		// remove gateway if it exists
 		if err = r.deleteGatewayConfig(ctx, params); err != nil {
@@ -514,7 +527,92 @@ func (r *ModelRegistryReconciler) deleteGatewayConfig(ctx context.Context, param
 	if err := r.Client.Delete(ctx, &gateway); client.IgnoreNotFound(err) != nil {
 		return err
 	}
+	return r.deleteGatewayRoutes(ctx, params.Name)
+}
+
+func (r *ModelRegistryReconciler) deleteGatewayRoutes(ctx context.Context, name string) error {
+	// delete all gateway routes
+	labels := client.MatchingLabels{
+		"app":                     name,
+		"component":               "model-registry",
+		"maistra.io/gateway-name": name,
+	}
+	var list routev1.RouteList
+	if err := r.Client.List(ctx, &list, labels); err != nil {
+		return err
+	}
+	for _, route := range list.Items {
+		if err := r.Client.Delete(ctx, &route); client.IgnoreNotFound(err) != nil {
+			return err
+		}
+	}
 	return nil
+}
+
+func (r *ModelRegistryReconciler) createOrUpdateGatewayRoutes(ctx context.Context, params *ModelRegistryParams,
+	registry *modelregistryv1alpha1.ModelRegistry, templateName string) (result OperationResult, err error) {
+	result = ResourceUnchanged
+
+	// get ingress gateway service
+	var serviceList corev1.ServiceList
+	labels := client.MatchingLabels{"istio": *params.Spec.Istio.Gateway.IstioIngress}
+	if params.Spec.Istio.Gateway.ControlPlane != nil {
+		labels["maistra.io/owner-name"] = *params.Spec.Istio.Gateway.ControlPlane
+	}
+	if err = r.Client.List(ctx, &serviceList, labels); err != nil {
+		return result, err
+	}
+	if len(serviceList.Items) != 1 {
+		return result, fmt.Errorf("missing unique ingress gateway service with labels %s, found %d services",
+			labels, len(serviceList.Items))
+	}
+	params.IngressService = &serviceList.Items[0]
+
+	// create/update REST route
+	result, err = r.handleGatewayRoute(ctx, params, registry, templateName, "-rest", params.Spec.Istio.Gateway.Rest.TLS)
+	if err != nil {
+		return result, err
+	}
+
+	// create/update gRPC route
+	result2, err := r.handleGatewayRoute(ctx, params, registry, templateName, "-grpc", params.Spec.Istio.Gateway.Grpc.TLS)
+	if err != nil {
+		return result2, err
+	}
+	if result2 != ResourceUnchanged {
+		result = result2
+	}
+
+	return result, nil
+}
+
+func (r *ModelRegistryReconciler) handleGatewayRoute(ctx context.Context, params *ModelRegistryParams,
+	registry *modelregistryv1alpha1.ModelRegistry, templateName string, suffix string,
+	tls *modelregistryv1alpha1.TLSServerSettings) (result OperationResult, err error) {
+
+	// route specific params
+	params.Host = params.Name + suffix
+	params.TLS = tls
+
+	var route routev1.Route
+	if err = r.Apply(params, templateName, &route); err != nil {
+		return result, err
+	}
+
+	if registry.Spec.Istio.Gateway.Rest.GatewayRoute == config.RouteEnabled {
+		result, err = r.createOrUpdate(ctx, route.DeepCopy(), &route)
+		if err != nil {
+			return result, err
+		}
+	} else {
+		// delete the route if it exists
+		if err = r.Client.Delete(ctx, &route); client.IgnoreNotFound(err) != nil {
+			result = ResourceUpdated
+			return result, err
+		}
+	}
+
+	return result, nil
 }
 
 func (r *ModelRegistryReconciler) createOrUpdateGateway(ctx context.Context, params *ModelRegistryParams,
@@ -796,11 +894,19 @@ func (r *ModelRegistryReconciler) createOrUpdate(ctx context.Context, currObj cl
 }
 
 // finalizeMemcached will perform the required operations before delete the CR.
-func (r *ModelRegistryReconciler) doFinalizerOperationsForModelRegistry(registry *modelregistryv1alpha1.ModelRegistry) {
+func (r *ModelRegistryReconciler) doFinalizerOperationsForModelRegistry(ctx context.Context, registry *modelregistryv1alpha1.ModelRegistry) error {
 	// TODO(user): Add the cleanup steps that the operator
 	// needs to do before the CR can be deleted. Examples
 	// of finalizers include performing backups and deleting
 	// resources that are not owned by this CR, like a PVC.
+
+	// delete cross-namespace resources
+	if err := r.Client.Delete(ctx, &userv1.Group{ObjectMeta: metav1.ObjectMeta{Name: registry.Name + "-users"}}); client.IgnoreNotFound(err) != nil {
+		return err
+	}
+	if err := r.deleteGatewayRoutes(ctx, registry.Name); err != nil {
+		return err
+	}
 
 	// Note: It is not recommended to use finalizers with the purpose of delete resources which are
 	// created and managed in the reconciliation. These, such as the Deployment created on this reconcile,
@@ -813,6 +919,8 @@ func (r *ModelRegistryReconciler) doFinalizerOperationsForModelRegistry(registry
 		fmt.Sprintf("Custom Resource %s is being deleted from the namespace %s",
 			registry.Name,
 			registry.Namespace))
+
+	return nil
 }
 
 // ModelRegistryParams is a wrapper for template parameters
@@ -820,6 +928,11 @@ type ModelRegistryParams struct {
 	Name      string
 	Namespace string
 	Spec      modelregistryv1alpha1.ModelRegistrySpec
+
+	// gateway route parameters
+	Host           string
+	IngressService *corev1.Service
+	TLS            *modelregistryv1alpha1.TLSServerSettings
 }
 
 // Apply executes given template name with params


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Create gateway service routes in model registry operator. This is required because OpenShift Service Mesh gateway route creation is deprecated and will be removed in coming versions. 
Fixes RHOAIENG-5559

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally by verifying that gateway routes are created automatically without having Istio Service Mesh gateway route creation enabled. 

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work