### PR TITLE
fix: add secure mysql db samples, fixes RHOAIENG-5436

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -204,6 +204,10 @@ certificates:
       --from-file=tls.key=certs/modelregistry-sample-grpc.domain.key \
       --from-file=tls.crt=certs/modelregistry-sample-grpc.domain.crt \
       --from-file=ca.crt=certs/domain.crt
+	$(KUBECTL) create secret generic model-registry-db-credential \
+      --from-file=tls.key=certs/model-registry-db.key \
+      --from-file=tls.crt=certs/model-registry-db.crt \
+      --from-file=ca.crt=certs/domain.crt
 
 .PHONY: certificates/clean
 certificates/clean:
@@ -211,4 +215,5 @@ certificates/clean:
 	mkdir -p certs
 	rm -f certs/*
 	# delete k8s secrets
-	$(KUBECTL) delete -n istio-system secrets modelregistry-sample-rest-credential modelregistry-sample-grpc-credential
+	$(KUBECTL) delete --ignore-not-found=true -n istio-system secrets modelregistry-sample-rest-credential modelregistry-sample-grpc-credential
+	$(KUBECTL) delete --ignore-not-found=true secrets model-registry-db-credential

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ make certificates/clean
 ```
 
 NOTE: The sample database secret `model-registry-db-credential` is created with the CA cert, server key and server cert. However, in production the model registry only needs a secret with the CA cert(s). The production database server will be configured with a secret containing the private key and server cert. 
+The sample certificates use a self-signed CA and does not do cert management like cert rotation, etc. Use your own certificate manager, e.g. https://cert-manager.io/ and create generic kubernetes secrets for REST, gRPC and database with the the keys `tls.key`, `tls.crt`, and `ca.crt`. 
 
 To disable Istio Gateway creation, create a kustomize overlay that removes the `gateway` yaml section in model registry custom resource or manually edit a sample yaml and it's corresponding `replacements.yaml` helper. 
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ make deploy
 * [PostgreSQL with Istio](config/samples/istio/postgres) PostgreSQL database, Istio, and plaintext Gateway
 * [MySQL with Istio and TLS](config/samples/istio/mysql-tls) MySQL database, Istio, and TLS Gateway endpoints
 * [PostgreSQL with Istio and TLS](config/samples/istio/postgres-tls) PostgreSQL database, Istio, and TLS Gateway endpoints
+* [Secure MySQL without Istio](config/samples/secure-db/mysql) plain Kubernetes model registry services with a sample SSL secured MySQL database
+* [Secure MySQL with Istio](config/samples/secure-db/mysql-tls) SSL secured MySQL database, Istio, and TLS Gateway
 
 #### Istio Samples
 **WARNING:** Istio samples without TLS are only meant for testing and demos to avoid having to create TLS certificates. They should only be used in local development clusters. 
@@ -91,19 +93,21 @@ If you have created your own RoleBindings to this Role, the operator will not re
 
 ##### TLS Certificates
 The project [Makefile](Makefile) includes targets to manage test TLS certificates using a self signed CA certificate. 
-To create test certificates in the directory [certs](certs) and Kubernetes secrets in the `istio-system` namespace, use the command:
+To create test certificates in the directory [certs](certs) and Kubernetes secrets in the `istio-system` namespace and current namespace, use the command:
 
 ```shell
 make certificates
 ```
 
-The test CA certificate is generated in the file [certs/domain.crt](certs/domain.crt) along with other certificates. See [generate_certs.sh](scripts/generate_certs.sh) for details. 
+The test CA certificate is generated in the file [certs/domain.crt](certs/domain.crt) along with certificates for REST, gRPC, and Database service. See [generate_certs.sh](scripts/generate_certs.sh) for details. 
 
 To cleanup the certificates and Kubernetes secrets, use the command:
 
 ```shell
 make certificates/clean
 ```
+
+NOTE: The sample database secret `model-registry-db-credential` is created with the CA cert, server key and server cert. However, in production the model registry only needs a secret with the CA cert(s). The production database server will be configured with a secret containing the private key and server cert. 
 
 To disable Istio Gateway creation, create a kustomize overlay that removes the `gateway` yaml section in model registry custom resource or manually edit a sample yaml and it's corresponding `replacements.yaml` helper. 
 
@@ -146,9 +150,11 @@ kubectl apply -k config/samples/istio/mysql
 kubectl apply -k config/samples/istio/postgres
 kubectl apply -k config/samples/istio/mysql-tls
 kubectl apply -k config/samples/istio/postgres-tls
+kubectl apply -k config/samples/secure-db/mysql
+kubectl apply -k config/samples/secure-db/mysql-tls
 ```
 
-This will create the appropriate model registry resource, which will be reconciled in the controller to create a model registry deployment with other Kubernetes, Istio, and Authorino resources as needed.
+This will create the appropriate database and model registry resources, which will be reconciled in the controller to create a model registry deployment with other Kubernetes, Istio, and Authorino resources as needed.
 
 4. Check that the sample model registry was created using the command:
 

--- a/config/samples/postgres/postgres-db.yaml
+++ b/config/samples/postgres/postgres-db.yaml
@@ -72,7 +72,9 @@ items:
           livenessProbe:
             exec:
               command:
-              - /usr/bin/pg_isready
+                - bash
+                - "-c"
+                - "/usr/bin/pg_isready -U $POSTGRES_USER -d $POSTGRES_DB"
             initialDelaySeconds: 30
             timeoutSeconds: 2
           name: postgresql

--- a/config/samples/secure-db/components/kustomization.yaml
+++ b/config/samples/secure-db/components/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+# Istio config patch
+patches:
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: model-registry-db
+    path: model-registry-db-secrets.yaml
+
+#+kubebuilder:scaffold:manifestskustomizesamples

--- a/config/samples/secure-db/components/model-registry-db-secrets.yaml
+++ b/config/samples/secure-db/components/model-registry-db-secrets.yaml
@@ -1,0 +1,15 @@
+- op: add
+  path: /spec/template/spec/containers/0/volumeMounts/-
+  value:
+    # name must match the volume name below
+    name: server-cert
+    mountPath: /etc/server-cert
+    readOnly: true
+- op: add
+  path: /spec/template/spec/volumes/-
+  value:
+    # The secret data is exposed to Containers in the Pod through a Volume.
+    name: server-cert
+    secret:
+      secretName: model-registry-db-credential
+      defaultMode: 0600

--- a/config/samples/secure-db/components/mysql/kustomization.yaml
+++ b/config/samples/secure-db/components/mysql/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+## Append samples of your project ##
+
+# MySQL tls args patch
+patches:
+  - path: mysql-ssl-args.yaml
+    target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: model-registry-db
+  - path: secure_mysql_modelregistry.yaml
+
+#+kubebuilder:scaffold:manifestskustomizesamples

--- a/config/samples/secure-db/components/mysql/mysql-ssl-args.yaml
+++ b/config/samples/secure-db/components/mysql/mysql-ssl-args.yaml
@@ -1,0 +1,16 @@
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value:
+    --ssl-ca=/etc/server-cert/ca.crt
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value:
+    --ssl-cert=/etc/server-cert/tls.crt
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value:
+    --ssl-key=/etc/server-cert/tls.key
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value:
+    --require-secure-transport

--- a/config/samples/secure-db/components/mysql/secure_mysql_modelregistry.yaml
+++ b/config/samples/secure-db/components/mysql/secure_mysql_modelregistry.yaml
@@ -1,0 +1,9 @@
+apiVersion: modelregistry.opendatahub.io/v1alpha1
+kind: ModelRegistry
+metadata:
+  name: modelregistry-sample
+spec:
+  mysql:
+    sslRootCertificateSecret:
+      name: model-registry-db-credential
+      key: ca.crt

--- a/config/samples/secure-db/mysql-tls/kustomization.yaml
+++ b/config/samples/secure-db/mysql-tls/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+## Append samples of your project ##
+resources:
+  - ../../istio/mysql-tls
+
+components:
+  - ../components
+  - ../components/mysql
+
+#+kubebuilder:scaffold:manifestskustomizesamples

--- a/config/samples/secure-db/mysql/kustomization.yaml
+++ b/config/samples/secure-db/mysql/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+## Append samples of your project ##
+resources:
+  - ../../mysql
+
+components:
+  - ../components/
+  - ../components/mysql
+
+#+kubebuilder:scaffold:manifestskustomizesamples

--- a/scripts/generate_certs.sh
+++ b/scripts/generate_certs.sh
@@ -10,3 +10,7 @@ openssl x509 -req -sha256 -days 365 -CA certs/domain.crt -CAkey certs/domain.key
 echo "subjectAltName = DNS:modelregistry-sample-grpc.$DOMAIN" > certs/modelregistry-sample-grpc.domain.ext
 openssl req -out certs/modelregistry-sample-grpc.domain.csr -newkey rsa:2048 -nodes -keyout certs/modelregistry-sample-grpc.domain.key -subj "/CN=modelregistry-sample-grpc/O=modelregistry organization" -addext "subjectAltName = DNS:modelregistry-sample-grpc.$DOMAIN"
 openssl x509 -req -sha256 -days 365 -CA certs/domain.crt -CAkey certs/domain.key -set_serial 0 -in certs/modelregistry-sample-grpc.domain.csr -out certs/modelregistry-sample-grpc.domain.crt -extfile certs/modelregistry-sample-grpc.domain.ext
+
+# create DB service cert and private key
+openssl req -out certs/model-registry-db.csr -newkey rsa:2048 -nodes -keyout certs/model-registry-db.key -subj "/CN=model-registry-db/O=modelregistry organization"
+openssl x509 -req -sha256 -days 365 -CA certs/domain.crt -CAkey certs/domain.key -set_serial 0 -in certs/model-registry-db.csr -out certs/model-registry-db.crt


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added secure mysql db samples without and with istio tls
Fixes RHOAIENG-5436
Fixes RHOAIENG-6713

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested samples manually, by first creating the DB cert using `make certificates` and then the appropriate `kubectl apply -k` command. 

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work