### PR TITLE
feat: add feature flag to control creation of auth config and policy resources, fixes RHOAIENG-6815

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,9 @@ OVERLAY ?= "default"
 # Disable operator webhooks by default for local testing
 ENABLE_WEBHOOKS ?= false
 
+# Enable Auth resources by default for local testing
+CREATE_AUTH_RESOURCES ?= true
+
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin
@@ -96,7 +99,7 @@ build: sync-images manifests generate fmt vet ## Build manager binary.
 
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.
-	ENABLE_WEBHOOKS=$(ENABLE_WEBHOOKS) go run ./cmd/main.go
+	ENABLE_WEBHOOKS=$(ENABLE_WEBHOOKS) CREATE_AUTH_RESOURCES=$(CREATE_AUTH_RESOURCES) go run ./cmd/main.go
 
 # If you wish to build the manager image targeting other platforms you can use the --platform flag.
 # (i.e. docker build --platform linux/arm64). However, you must enable docker buildKit for it.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -50,7 +50,10 @@ var (
 	setupLog = ctrl.Log.WithName("setup")
 )
 
-const EnableWebhooks = "ENABLE_WEBHOOKS"
+const (
+	EnableWebhooks      = "ENABLE_WEBHOOKS"
+	CreateAuthResources = "CREATE_AUTH_RESOURCES"
+)
 
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
@@ -150,16 +153,19 @@ func main() {
 	}
 
 	enableWebhooks := os.Getenv(EnableWebhooks) != "false"
+	createAuthResources := os.Getenv(CreateAuthResources) != "false"
+
 	if err = (&controller.ModelRegistryReconciler{
-		Client:         client,
-		Scheme:         mgr.GetScheme(),
-		Recorder:       mgr.GetEventRecorderFor("modelregistry-controller"),
-		Log:            ctrl.Log.WithName("controller"),
-		Template:       template,
-		EnableWebhooks: enableWebhooks,
-		IsOpenShift:    isOpenShift,
-		HasIstio:       hasAuthorino && hasIstio,
-		Audiences:      tokenReview.Status.Audiences,
+		Client:              client,
+		Scheme:              mgr.GetScheme(),
+		Recorder:            mgr.GetEventRecorderFor("modelregistry-controller"),
+		Log:                 ctrl.Log.WithName("controller"),
+		Template:            template,
+		EnableWebhooks:      enableWebhooks,
+		IsOpenShift:         isOpenShift,
+		HasIstio:            hasAuthorino && hasIstio,
+		Audiences:           tokenReview.Status.Audiences,
+		CreateAuthResources: createAuthResources,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ModelRegistry")
 		os.Exit(1)

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -79,6 +79,8 @@ spec:
             value: quay.io/opendatahub/model-registry:latest
           - name: ENABLE_WEBHOOKS
             value: "false"
+          - name: CREATE_AUTH_RESOURCES
+            value: "true"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/config/overlays/odh/params.env
+++ b/config/overlays/odh/params.env
@@ -1,3 +1,4 @@
 IMAGES_MODELREGISTRY_OPERATOR=quay.io/opendatahub/model-registry-operator:latest
 IMAGES_GRPC_SERVICE=quay.io/opendatahub/mlmd-grpc-server:latest
 IMAGES_REST_SERVICE=quay.io/opendatahub/model-registry:latest
+CREATE_AUTH_RESOURCES=true

--- a/config/overlays/odh/replacements.yaml
+++ b/config/overlays/odh/replacements.yaml
@@ -29,3 +29,13 @@
         name: controller-manager
       fieldPaths:
         - spec.template.spec.containers.[name=manager].env.[name=REST_IMAGE].value
+- source:
+    kind: ConfigMap
+    name: model-registry-operator-parameters
+    fieldPath: data.CREATE_AUTH_RESOURCES
+  targets:
+    - select:
+        kind: Deployment
+        name: controller-manager
+      fieldPaths:
+        - spec.template.spec.containers.[name=manager].env.[name=CREATE_AUTH_RESOURCES].value


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added feature flag CREATE_AUTH_RESOURCES to control creation of auth config and policy resources.
The feature flag is configurable as an env variable and is also added to params.env for configuration through odh installer.
Fixes RHOAIENG-6815

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually by running the operator locally using:
`CREATE_AUTH_RESOURCES=false make run`

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work