### PR TITLE
feat: add watch for gateway routes to handle user changes to operator created routes, fixes RHOAIENG-8897

### DIFF
--- a/internal/controller/modelregistry_controller_status.go
+++ b/internal/controller/modelregistry_controller_status.go
@@ -383,7 +383,7 @@ func (r *ModelRegistryReconciler) SetGatewayCondition(ctx context.Context, req c
 	}
 
 	// check routes Ingress Admitted condition
-	if available {
+	if available && r.IsOpenShift {
 		message, available = r.CheckGatewayRoutes(ctx, modelRegistry, name, log, message, available)
 
 		// set Gateway condition true if routes are available


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add watch for gateway routes. Since these are created by operator, it needs to look for changes to routes to ensure the haven't been externally broken
Fixes RHOAIENG-8897

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested by manually trying to delete the routes

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work