### PR TITLE
fix: start condition check for deployment with the assumption that it is not available, fixes RHOAIENG-9184

### DIFF
--- a/internal/controller/modelregistry_controller_status.go
+++ b/internal/controller/modelregistry_controller_status.go
@@ -99,7 +99,8 @@ func (r *ModelRegistryReconciler) setRegistryStatus(ctx context.Context, req ctr
 	log.V(10).Info("Found service deployment", "name", len(deployment.Name))
 
 	// check deployment conditions errors
-	available := true
+	// start with available=false to force DeploymentAvailable condition to set it to true later
+	available := false
 	failed := false
 	progressing := true
 	for _, c := range deployment.Status.Conditions {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Start by assuming that DeploymentAvailable condition is missing/not available, i.e. only set MR status to available when deployment is actually available.
This can happen when the Deployment is initialized in K8s but without any of it's conditions set.
Fixes RHOAIENG-9184

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally by waiting for availability right away by using the command:
```
kubectl apply -k config/samples/postgres/; kubectl wait --for=condition=Available=true modelregistries/modelregistry-sample --timeout=5m
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work