### PR TITLE
Update db test secrets

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,12 @@
+[allowlist]
+  description = "Global Allowlist"
+        
+  # Ignore based on any subset of the line
+  regexes = [
+    
+    # Ignore specific database password
+    '''database-password\s*:\s*"The BlurstOfTimes"''',
+
+    # Ignore specific database user
+    '''database-user\s*:\s*"mlmduser"'''
+  ]

--- a/config/samples/mysql/mysql-db.yaml
+++ b/config/samples/mysql/mysql-db.yaml
@@ -120,7 +120,7 @@ items:
     name: model-registry-db
   stringData:
     database-name: "model_registry"
-    database-password: "TheBlurstOfTimes"
-    database-user: "mlmduser"
+    database-password: "TheBlurstOfTimes" # notsecret
+    database-user: "mlmduser" # notsecret
 kind: List
 metadata: {}

--- a/config/samples/postgres/postgres-db.yaml
+++ b/config/samples/postgres/postgres-db.yaml
@@ -112,7 +112,7 @@ items:
     name: model-registry-db
   stringData:
     database-name: "model-registry"
-    database-password: "TheBlurstOfTimes"
-    database-user: "mlmduser"
+    database-password: "TheBlurstOfTimes" # notsecret
+    database-user: "mlmduser" # notsecret
 kind: List
 metadata: {}


### PR DESCRIPTION
This commit will allow the test credentials for the postgress and mysql databases to pass prodsec scanning.

It should stop emails being received by the team informing us we have a potential data leak because of test credentials.

Instructions on how should be done are found [here](https://source.redhat.com/departments/it/it-information-security/wiki/pattern_distribution_server#handling-false-positives).

## Description
Added '# notsecret tag to database-password and database-user lines in both postgres-db.yaml and mysql-db.yaml

Added a .gitleaks.toml file to allow prodsec to scan all previous commits.

## How Has This Been Tested?
It has been tested locally using gitleaks cli.

