### PR TITLE
feat: copy model registry display name and description annotations to model registry service, fixes RHOAIENG-9376

### DIFF
--- a/internal/controller/modelregistry_controller.go
+++ b/internal/controller/modelregistry_controller.go
@@ -51,7 +51,11 @@ import (
 	"text/template"
 )
 
-const modelRegistryFinalizer = "modelregistry.opendatahub.io/finalizer"
+const (
+	modelRegistryFinalizer = "modelregistry.opendatahub.io/finalizer"
+	DisplayNameAnnotation  = "openshift.io/display-name"
+	DescriptionAnnotation  = "openshift.io/description"
+)
 
 // ModelRegistryReconciler reconciles a ModelRegistry object
 type ModelRegistryReconciler struct {
@@ -787,6 +791,21 @@ func (r *ModelRegistryReconciler) createOrUpdateService(ctx context.Context, par
 	if err = ctrl.SetControllerReference(registry, &service, r.Scheme); err != nil {
 		return result, err
 	}
+
+	// copy display name and description from MR to the Service
+	if name, ok := registry.Annotations[DisplayNameAnnotation]; ok {
+		if service.Annotations == nil {
+			service.Annotations = make(map[string]string)
+		}
+		service.Annotations[DisplayNameAnnotation] = name
+	}
+	if description, ok := registry.Annotations[DescriptionAnnotation]; ok {
+		if service.Annotations == nil {
+			service.Annotations = make(map[string]string)
+		}
+		service.Annotations[DescriptionAnnotation] = description
+	}
+
 	if result, err = r.createOrUpdate(ctx, service.DeepCopy(), &service); err != nil {
 		return result, err
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Copy model registry display name and desription annotations only to model registry service. 
This will let odh dashboard read them from the service itself instead of requiring get/list access to model registry custom resource.
Fixes RHOAIENG-9376

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work