### PR TITLE
feat: set domain automatically in Openshift cluster, fixes RHOAIENG-5123

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -197,7 +197,7 @@ $(ENVTEST): $(LOCALBIN)
 .PHONY: certificates
 certificates:
 	# generate TLS certs
-	scripts/generate_certs.sh $(DOMAIN)
+	scripts/generate_certs.sh $(or $(DOMAIN),$(shell oc get ingresses.config/cluster -o jsonpath='{.spec.domain}'))
 	# create secrets from TLS certs
 	$(KUBECTL) create secret -n istio-system generic modelregistry-sample-rest-credential \
       --from-file=tls.key=certs/modelregistry-sample-rest.domain.key \

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ If Authorino provider is from a non Open Data Hub cluster, configure its selecto
 To use the Istio model registry samples the following configuration data is needed in the [istio.env](config/samples/istio/components/istio.env) file:
 
 * AUTH_PROVIDER - name of the authorino external auth provider configured in the Istio control plane (defaults to `opendatahub-auth-provider` for Open Data Hub data science cluster with OpenShift Service Mesh enabled).
-* DOMAIN - hostname domain suffix for gateway endpoints. 
+* DOMAIN - hostname domain suffix for gateway endpoints. This field is optional in an OpenShift cluster and set automatically if left empty.
 This depends upon your cluster's external load balancer config. In OpenShift clusters, it can be obtained with the command:
 ```shell
 oc get ingresses.config/cluster -o jsonpath='{.spec.domain}'

--- a/api/v1alpha1/modelregistry_types.go
+++ b/api/v1alpha1/modelregistry_types.go
@@ -224,10 +224,12 @@ type ServerConfig struct {
 }
 
 type GatewayConfig struct {
-	//+kubebuilder:required
+	//+optional
 
-	// Domain name for Gateway configuration
-	Domain string `json:"domain"`
+	// Domain name for Gateway configuration.
+	// If not provided, it is set automatically using model registry operator env variable DEFAULT_DOMAIN.
+	// If the env variable is not set, it is set to the OpenShift `cluster` ingress domain in an OpenShift cluster.
+	Domain string `json:"domain,omitempty"`
 
 	//+kubebuilder:default=ingressgateway
 

--- a/config/crd/bases/modelregistry.opendatahub.io_modelregistries.yaml
+++ b/config/crd/bases/modelregistry.opendatahub.io_modelregistries.yaml
@@ -161,7 +161,11 @@ spec:
                         description: Maistra/OpenShift Servicemesh control plane name
                         type: string
                       domain:
-                        description: Domain name for Gateway configuration
+                        description: Domain name for Gateway configuration. If not
+                          provided, it is set automatically using model registry operator
+                          env variable DEFAULT_DOMAIN. If the env variable is not
+                          set, it is set to the OpenShift `cluster` ingress domain
+                          in an OpenShift cluster.
                         type: string
                       grpc:
                         description: gRPC  gateway server config
@@ -317,7 +321,6 @@ spec:
                             type: object
                         type: object
                     required:
-                    - domain
                     - grpc
                     - rest
                     type: object

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -81,6 +81,8 @@ spec:
             value: "false"
           - name: CREATE_AUTH_RESOURCES
             value: "true"
+          - name: DEFAULT_DOMAIN
+            value: ""
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -29,6 +29,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - config.openshift.io
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - ""
   resources:
   - events

--- a/config/samples/istio/components/istio.env
+++ b/config/samples/istio/components/istio.env
@@ -1,5 +1,5 @@
 AUTH_PROVIDER=opendatahub-auth-provider
-DOMAIN=my-domain
+DOMAIN=
 ISTIO_INGRESS=ingressgateway
 REST_CREDENTIAL_NAME=modelregistry-sample-rest-credential
 GRPC_CREDENTIAL_NAME=modelregistry-sample-grpc-credential

--- a/scripts/generate_certs.sh
+++ b/scripts/generate_certs.sh
@@ -1,4 +1,8 @@
 DOMAIN=$1
+if [ -z ${DOMAIN} ]; then
+  echo "Missing command line parameter for certificate domain"
+  exit 1
+fi
 mkdir -p certs
 # create CA cert
 openssl req -x509 -sha256 -nodes -days 365 -newkey rsa:2048 -subj "/O=modelregistry Inc./CN=$DOMAIN" -keyout certs/domain.key -out certs/domain.crt


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Set domain automatically in Openshift cluster either from an env variable in the operator, or from Openshift cluster if available
Fixes RHOAIENG-5123

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The default istio.env config file now has an empty DOMAIN parameter

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work