### PR TITLE
feat: add annotations for external service host and port in MR service, fixes RHOAIENG-11092

### DIFF
--- a/internal/controller/config/templates/service.yaml.tmpl
+++ b/internal/controller/config/templates/service.yaml.tmpl
@@ -14,7 +14,6 @@ metadata:
     app.kubernetes.io/managed-by: model-registry-operator
   annotations:
     {{- if and .Spec.Istio .Spec.Istio.Gateway .Spec.Istio.Gateway.Domain}}
-    routing.opendatahub.io/external-address: {{.Name}}-rest.{{.Spec.Istio.Gateway.Domain}}:{{.Spec.Istio.Gateway.Rest.Port}}
     routing.opendatahub.io/external-address-rest: {{.Name}}-rest.{{.Spec.Istio.Gateway.Domain}}:{{.Spec.Istio.Gateway.Rest.Port}}
     routing.opendatahub.io/external-address-grpc: {{.Name}}-grpc.{{.Spec.Istio.Gateway.Domain}}:{{.Spec.Istio.Gateway.Grpc.Port}}
     {{- end}}

--- a/internal/controller/config/templates/service.yaml.tmpl
+++ b/internal/controller/config/templates/service.yaml.tmpl
@@ -12,6 +12,12 @@ metadata:
     app.kubernetes.io/created-by: model-registry-operator
     app.kubernetes.io/part-of: model-registry
     app.kubernetes.io/managed-by: model-registry-operator
+  annotations:
+    {{- if and .Spec.Istio .Spec.Istio.Gateway .Spec.Istio.Gateway.Domain}}
+    routing.opendatahub.io/external-address: {{.Name}}-rest.{{.Spec.Istio.Gateway.Domain}}:{{.Spec.Istio.Gateway.Rest.Port}}
+    routing.opendatahub.io/external-address-rest: {{.Name}}-rest.{{.Spec.Istio.Gateway.Domain}}:{{.Spec.Istio.Gateway.Rest.Port}}
+    routing.opendatahub.io/external-address-grpc: {{.Name}}-grpc.{{.Spec.Istio.Gateway.Domain}}:{{.Spec.Istio.Gateway.Grpc.Port}}
+    {{- end}}
 spec:
   ports:
     - name: grpc-api


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add annotations for external service host and port in k8s MR service
Fixes RHOAIENG-11092

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested istio and non-istio samples to look for annotations being set correctly in istio sample only.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work