### PR TITLE
fix: add missing DB labels in DB secrets, fixes RHOAIENG-12126

### DIFF
--- a/config/samples/mysql/mysql-db.yaml
+++ b/config/samples/mysql/mysql-db.yaml
@@ -128,6 +128,11 @@ items:
 - apiVersion: v1
   kind: Secret
   metadata:
+    labels:
+      app.kubernetes.io/name: model-registry-db
+      app.kubernetes.io/instance: model-registry-db
+      app.kubernetes.io/part-of: model-registry-db
+      app.kubernetes.io/managed-by: kustomize
     annotations:
       template.openshift.io/expose-database_name: '{.data[''database-name'']}'
       template.openshift.io/expose-password: '{.data[''database-password'']}'

--- a/config/samples/postgres/postgres-db.yaml
+++ b/config/samples/postgres/postgres-db.yaml
@@ -120,6 +120,11 @@ items:
 - apiVersion: v1
   kind: Secret
   metadata:
+    labels:
+      app.kubernetes.io/name: model-registry-db
+      app.kubernetes.io/instance: model-registry-db
+      app.kubernetes.io/part-of: model-registry-db
+      app.kubernetes.io/managed-by: kustomize
     annotations:
       template.openshift.io/expose-database_name: '{.data[''database-name'']}'
       template.openshift.io/expose-password: '{.data[''database-password'']}'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added missing DB labels in DB secrets, without which sample DB cannot be deloyed using a label filter.
Fixes RHOAIENG-12126

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Used the following command in a new namespace to create a test DB:
```shell
oc apply -k config/samples/secure-db/mysql/ -l app.kubernetes.io/name=model-registry-db
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work