### PR TITLE
feat: set authorino config properties in odh overlay from odh operator configmap auth-refs, fixes RHOAIENG-5076

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -169,23 +169,7 @@ func main() {
 	// default auth env variables
 	defaultAuthProvider := os.Getenv(DefaultAuthProvider)
 	defaultAuthConfigLabelsString := os.Getenv(DefaultAuthConfigLabels)
-	defaultAuthConfigLabels := make(map[string]string)
-	if len(defaultAuthConfigLabelsString) != 0 {
-		// split key=value pairs separated by commas
-		pairs := strings.Split(defaultAuthConfigLabelsString, ",")
-		for _, pair := range pairs {
-			// split key value pair
-			parts := strings.SplitN(pair, "=", 2)
-			if len(parts) > 0 {
-				key := parts[0]
-				var value string
-				if len(parts) > 1 {
-					value = parts[1]
-				}
-				defaultAuthConfigLabels[key] = value
-			}
-		}
-	}
+	defaultAuthConfigLabels := getAuthConfigLabels(defaultAuthConfigLabelsString)
 	setupLog.Info("default registry authorino config", DefaultAuthProvider, defaultAuthProvider, DefaultAuthConfigLabels, defaultAuthConfigLabels)
 
 	if err = (&controller.ModelRegistryReconciler{
@@ -229,4 +213,25 @@ func main() {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}
+}
+
+func getAuthConfigLabels(defaultAuthConfigLabelsString string) map[string]string {
+	defaultAuthConfigLabels := make(map[string]string)
+	if len(defaultAuthConfigLabelsString) != 0 {
+		// split key=value pairs separated by commas
+		pairs := strings.Split(defaultAuthConfigLabelsString, ",")
+		for _, pair := range pairs {
+			// split key value pair
+			parts := strings.SplitN(pair, "=", 2)
+			if len(parts) > 0 {
+				key := parts[0]
+				var value string
+				if len(parts) > 1 {
+					value = parts[1]
+				}
+				defaultAuthConfigLabels[key] = value
+			}
+		}
+	}
+	return defaultAuthConfigLabels
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -26,6 +26,7 @@ import (
 	authentication "k8s.io/api/authentication/v1"
 	"k8s.io/client-go/discovery"
 	"os"
+	"strings"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
@@ -52,10 +53,12 @@ var (
 )
 
 const (
-	EnableWebhooks      = "ENABLE_WEBHOOKS"
-	CreateAuthResources = "CREATE_AUTH_RESOURCES"
-	DefaultDomain       = "DEFAULT_DOMAIN"
-	DefaultCert         = "DEFAULT_CERT"
+	EnableWebhooks          = "ENABLE_WEBHOOKS"
+	CreateAuthResources     = "CREATE_AUTH_RESOURCES"
+	DefaultDomain           = "DEFAULT_DOMAIN"
+	DefaultCert             = "DEFAULT_CERT"
+	DefaultAuthProvider     = "DEFAULT_AUTH_PROVIDER"
+	DefaultAuthConfigLabels = "DEFAULT_AUTH_CONFIG_LABELS"
 )
 
 func init() {
@@ -155,25 +158,51 @@ func main() {
 			hasIstio = true
 		}
 	}
+	setupLog.Info("cluster config", "isOpenShift", isOpenShift, "hasAuthorino", hasAuthorino, "hasIstio", hasIstio)
 
 	enableWebhooks := os.Getenv(EnableWebhooks) != "false"
 	createAuthResources := os.Getenv(CreateAuthResources) != "false"
 	defaultDomain := os.Getenv(DefaultDomain)
 	defaultCert := os.Getenv(DefaultCert)
+	setupLog.Info("default registry config", DefaultDomain, defaultDomain, DefaultCert, defaultCert)
+
+	// default auth env variables
+	defaultAuthProvider := os.Getenv(DefaultAuthProvider)
+	defaultAuthConfigLabelsString := os.Getenv(DefaultAuthConfigLabels)
+	defaultAuthConfigLabels := make(map[string]string)
+	if len(defaultAuthConfigLabelsString) != 0 {
+		// split key=value pairs separated by commas
+		pairs := strings.Split(defaultAuthConfigLabelsString, ",")
+		for _, pair := range pairs {
+			// split key value pair
+			parts := strings.SplitN(pair, "=", 2)
+			if len(parts) > 0 {
+				key := parts[0]
+				var value string
+				if len(parts) > 1 {
+					value = parts[1]
+				}
+				defaultAuthConfigLabels[key] = value
+			}
+		}
+	}
+	setupLog.Info("default registry authorino config", DefaultAuthProvider, defaultAuthProvider, DefaultAuthConfigLabels, defaultAuthConfigLabels)
 
 	if err = (&controller.ModelRegistryReconciler{
-		Client:              client,
-		Scheme:              mgr.GetScheme(),
-		Recorder:            mgr.GetEventRecorderFor("modelregistry-controller"),
-		Log:                 ctrl.Log.WithName("controller"),
-		Template:            template,
-		EnableWebhooks:      enableWebhooks,
-		IsOpenShift:         isOpenShift,
-		HasIstio:            hasAuthorino && hasIstio,
-		Audiences:           tokenReview.Status.Audiences,
-		CreateAuthResources: createAuthResources,
-		DefaultDomain:       defaultDomain,
-		DefaultCert:         defaultCert,
+		Client:                  client,
+		Scheme:                  mgr.GetScheme(),
+		Recorder:                mgr.GetEventRecorderFor("modelregistry-controller"),
+		Log:                     ctrl.Log.WithName("controller"),
+		Template:                template,
+		EnableWebhooks:          enableWebhooks,
+		IsOpenShift:             isOpenShift,
+		HasIstio:                hasAuthorino && hasIstio,
+		Audiences:               tokenReview.Status.Audiences,
+		CreateAuthResources:     createAuthResources,
+		DefaultDomain:           defaultDomain,
+		DefaultCert:             defaultCert,
+		DefaultAuthProvider:     defaultAuthProvider,
+		DefaultAuthConfigLabels: defaultAuthConfigLabels,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ModelRegistry")
 		os.Exit(1)

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -85,6 +85,10 @@ spec:
             value: ""
           - name: DEFAULT_CERT
             value: ""
+          - name: DEFAULT_AUTH_PROVIDER
+            value: ""
+          - name: DEFAULT_AUTH_CONFIG_LABELS
+            value: ""
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/config/overlays/odh/kustomization.yaml
+++ b/config/overlays/odh/kustomization.yaml
@@ -14,6 +14,9 @@ patches:
 # patch to add serving cert to auth proxy container
 - path: patches/manager_auth_proxy_patch.yaml
 
+# patch to add auth config properties
+- path: patches/manager_auth_config_patch.yaml
+
 # patch to add webhooks and CA bundles to CRD
 - path: patches/webhook_in_modelregistries.yaml
 #+kubebuilder:scaffold:crdkustomizewebhookpatch

--- a/config/overlays/odh/patches/manager_auth_config_patch.yaml
+++ b/config/overlays/odh/patches/manager_auth_config_patch.yaml
@@ -1,0 +1,26 @@
+# This patch injects auth config properties from auth-refs configmap in the controller manager
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        # name must match the volume name below
+        env:
+          - name: DEFAULT_AUTH_PROVIDER
+            valueFrom:
+              configMapKeyRef:
+                # AUTH_NAMESPACE has the external authorization provider name
+                # used in the istio servicemeshcontrolplane (smcp) config
+                key: AUTH_NAMESPACE
+                name: auth-refs
+          - name: DEFAULT_AUTH_CONFIG_LABELS
+            valueFrom:
+              configMapKeyRef:
+                # AUTHORINO_LABEL has the label selector for authorino
+                key: AUTHORINO_LABEL
+                name: auth-refs


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
ODH operator writes authorino auth config to a configmap auth-refs in the same namespace as the odh component operators
Set authorino config properties in odh overlay from this configmap
Fixes RHOAIENG-5076

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested by creating operator image locally and using the ODH overlay to test whether configmap properties are injected and used correctly in the operator for a model registry with the yaml:
```yaml
apiVersion: modelregistry.opendatahub.io/v1alpha1
kind: ModelRegistry
metadata:
  annotations:
  labels:
    app.kubernetes.io/created-by: model-registry-operator
    app.kubernetes.io/instance: modelregistry-sample
    app.kubernetes.io/managed-by: kustomize
    app.kubernetes.io/name: modelregistry
    app.kubernetes.io/part-of: model-registry-operator
  name: modelregistry-sample
  namespace: odh-model-registries
spec:
  grpc: {}
  rest: {}
  istio:
    gateway:
      grpc:
        tls: {}
      rest:
        tls: {}
  mysql:
    database: model_registry
    host: model-registry-db
    passwordSecret:
      key: database-password
      name: model-registry-db
    port: 3306
    skipDBCreation: false
    sslRootCertificateSecret:
      key: ca.crt
      name: model-registry-db-credential
    username: mlmduser
```

The operator automatically populates the missing auth config properties.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work