### PR TITLE
feat: switch from go build to make build in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi8/go-toolset:1.20.12 as builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.20.12 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,18 +16,25 @@ COPY cmd/main.go cmd/main.go
 COPY api/ api/
 COPY internal/controller/ internal/controller/
 
+# Copy Makefile and build command requirements
+COPY config/ config/
+COPY hack/ hack/
+COPY Makefile Makefile
+
+USER root
+
 # Build
 # the GOARCH has not a default value to allow the binary be built according to the host where the command
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} make build
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 WORKDIR /
-COPY --from=builder /workspace/manager .
+COPY --from=builder /workspace/bin/manager .
 USER 65532:65532
 
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
## Description

Switched from `go build` to `make build` in the Dockerfile, also I have added the minimal needed COPY to make the command work, also I had to switch to USER root to make sed work, as I had the following error:

```
# sync model-registry image
sed "s|quay.io/opendatahub/model-registry:.*|quay.io/opendatahub/model-registry:latest|" -i ./config/manager/manager.yaml
sed: couldn't open temporary file ./config/manager/sedmgPg4K: Permission denied
```

(solved by following this issue https://github.com/containers/podman/issues/5197)

## How Has This Been Tested?

run `make docker-build` locally

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
