### PR TITLE
feat: moved runtime defaults to spec status, fixes RHOAIENG-15033

### DIFF
--- a/api/v1alpha1/modelregistry_annotations.go
+++ b/api/v1alpha1/modelregistry_annotations.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"github.com/opendatahub-io/model-registry-operator/internal/controller/config"
+)
+
+const (
+	resetSpecDefaultsAnnotation = "modelregistry.opendatahub.io/reset-spec-defaults"
+)
+
+type annHandlerFunc func(*ModelRegistry)
+
+var annotationHandlers = map[string]annHandlerFunc{
+	resetSpecDefaultsAnnotation: HandleResetDefaults,
+}
+
+// HandleAnnotations calls annotation handlers
+func (r *ModelRegistry) HandleAnnotations() {
+	annotations := r.GetAnnotations()
+	if len(annotations) > 0 {
+		for ann, handlerFunc := range annotationHandlers {
+			_, found := annotations[ann]
+			if found {
+				modelregistrylog.Info("handle annotation", "name", r.Name, "annotation", ann)
+				handlerFunc(r)
+			}
+		}
+	}
+}
+
+// HandleResetDefaults resets operator default properties
+func HandleResetDefaults(r *ModelRegistry) {
+	// remove runtime default properties
+	const emptyValue = ""
+	r.Spec.Grpc.Image = emptyValue
+	r.Spec.Grpc.Resources = nil
+	r.Spec.Rest.Image = emptyValue
+	r.Spec.Rest.Resources = nil
+
+	// reset istio defaults
+	if r.Spec.Istio != nil {
+		r.Spec.Istio.Audiences = make([]string, 0)
+		r.Spec.Istio.AuthProvider = emptyValue
+		r.Spec.Istio.AuthConfigLabels = make(map[string]string)
+
+		if r.Spec.Istio.Gateway != nil {
+			r.Spec.Istio.Gateway.Domain = emptyValue
+
+			// reset default cert, if set
+			defaultCert := config.GetDefaultCert()
+			if r.Spec.Istio.Gateway.Rest.TLS != nil && r.Spec.Istio.Gateway.Rest.TLS.Mode != DefaultTlsMode &&
+				r.Spec.Istio.Gateway.Rest.TLS.CredentialName != nil && *r.Spec.Istio.Gateway.Rest.TLS.CredentialName == defaultCert {
+				r.Spec.Istio.Gateway.Rest.TLS.CredentialName = nil
+			}
+			if r.Spec.Istio.Gateway.Grpc.TLS != nil && r.Spec.Istio.Gateway.Grpc.TLS.Mode != DefaultTlsMode &&
+				r.Spec.Istio.Gateway.Grpc.TLS.CredentialName != nil && *r.Spec.Istio.Gateway.Grpc.TLS.CredentialName == defaultCert {
+				r.Spec.Istio.Gateway.Grpc.TLS.CredentialName = nil
+			}
+		}
+	}
+
+	// remove annotation, since properties were reset
+	annotations := r.GetAnnotations()
+	delete(annotations, resetSpecDefaultsAnnotation)
+	r.SetAnnotations(annotations)
+}

--- a/api/v1alpha1/modelregistry_types.go
+++ b/api/v1alpha1/modelregistry_types.go
@@ -363,6 +363,9 @@ type ModelRegistryStatus struct {
 	// Formatted Host names separated by comma
 	HostsStr string `json:"hostsStr,omitempty"`
 
+	// SpecDefaults is a JSON string containing default spec values that were used for model registry deployment
+	SpecDefaults string `json:"specDefaults,omitempty"`
+
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 

--- a/api/v1alpha1/modelregistry_webhook.go
+++ b/api/v1alpha1/modelregistry_webhook.go
@@ -65,6 +65,9 @@ var (
 func (r *ModelRegistry) Default() {
 	modelregistrylog.Info("default", "name", r.Name)
 
+	// handle annotation mutations
+	r.HandleAnnotations()
+
 	if len(r.Spec.Rest.ServiceRoute) == 0 {
 		r.Spec.Rest.ServiceRoute = config.RouteDisabled
 	}

--- a/api/v1alpha1/modelregistry_webhook.go
+++ b/api/v1alpha1/modelregistry_webhook.go
@@ -65,21 +65,8 @@ var (
 func (r *ModelRegistry) Default() {
 	modelregistrylog.Info("default", "name", r.Name)
 
-	if r.Spec.Grpc.Resources == nil {
-		r.Spec.Grpc.Resources = config.MlmdGRPCResourceRequirements.DeepCopy()
-	}
-	if len(r.Spec.Grpc.Image) == 0 {
-		r.Spec.Grpc.Image = config.GetStringConfigWithDefault(config.GrpcImage, config.DefaultGrpcImage)
-	}
-
 	if len(r.Spec.Rest.ServiceRoute) == 0 {
 		r.Spec.Rest.ServiceRoute = config.RouteDisabled
-	}
-	if r.Spec.Rest.Resources == nil {
-		r.Spec.Rest.Resources = config.MlmdRestResourceRequirements.DeepCopy()
-	}
-	if len(r.Spec.Rest.Image) == 0 {
-		r.Spec.Rest.Image = config.GetStringConfigWithDefault(config.RestImage, config.DefaultRestImage)
 	}
 
 	// Fixes default database configs that get set for some reason in Kind cluster
@@ -96,24 +83,8 @@ func (r *ModelRegistry) Default() {
 		if len(r.Spec.Istio.TlsMode) == 0 {
 			r.Spec.Istio.TlsMode = DefaultTlsMode
 		}
-		// set default audiences
-		if len(r.Spec.Istio.Audiences) == 0 {
-			r.Spec.Istio.Audiences = config.GetDefaultAudiences()
-		}
-		// set default authprovider
-		if len(r.Spec.Istio.AuthProvider) == 0 {
-			r.Spec.Istio.AuthProvider = config.GetDefaultAuthProvider()
-		}
-		// set default authconfig labels
-		if len(r.Spec.Istio.AuthConfigLabels) == 0 {
-			r.Spec.Istio.AuthConfigLabels = config.GetDefaultAuthConfigLabels()
-		}
 
 		if r.Spec.Istio.Gateway != nil {
-			// set default domain
-			if len(r.Spec.Istio.Gateway.Domain) == 0 {
-				r.Spec.Istio.Gateway.Domain = config.GetDefaultDomain()
-			}
 			// set ingress gateway if not set
 			if r.Spec.Istio.Gateway.IstioIngress == nil {
 				r.Spec.Istio.Gateway.IstioIngress = &defaultIstioGateway
@@ -141,6 +112,48 @@ func (r *ModelRegistry) Default() {
 			if len(r.Spec.Istio.Gateway.Grpc.GatewayRoute) == 0 {
 				r.Spec.Istio.Gateway.Grpc.GatewayRoute = config.RouteEnabled
 			}
+		}
+	}
+}
+
+// RuntimeDefaults sets default values from the operator environment, which could change at runtime
+func (r *ModelRegistry) RuntimeDefaults() {
+	modelregistrylog.Info("runtime defaults", "name", r.Name)
+
+	if r.Spec.Grpc.Resources == nil {
+		r.Spec.Grpc.Resources = config.MlmdGRPCResourceRequirements.DeepCopy()
+	}
+	if len(r.Spec.Grpc.Image) == 0 {
+		r.Spec.Grpc.Image = config.GetStringConfigWithDefault(config.GrpcImage, config.DefaultGrpcImage)
+	}
+
+	if r.Spec.Rest.Resources == nil {
+		r.Spec.Rest.Resources = config.MlmdRestResourceRequirements.DeepCopy()
+	}
+	if len(r.Spec.Rest.Image) == 0 {
+		r.Spec.Rest.Image = config.GetStringConfigWithDefault(config.RestImage, config.DefaultRestImage)
+	}
+
+	// istio defaults
+	if r.Spec.Istio != nil {
+		// set default audiences
+		if len(r.Spec.Istio.Audiences) == 0 {
+			r.Spec.Istio.Audiences = config.GetDefaultAudiences()
+		}
+		// set default authprovider
+		if len(r.Spec.Istio.AuthProvider) == 0 {
+			r.Spec.Istio.AuthProvider = config.GetDefaultAuthProvider()
+		}
+		// set default authconfig labels
+		if len(r.Spec.Istio.AuthConfigLabels) == 0 {
+			r.Spec.Istio.AuthConfigLabels = config.GetDefaultAuthConfigLabels()
+		}
+
+		if r.Spec.Istio.Gateway != nil {
+			// set default domain
+			if len(r.Spec.Istio.Gateway.Domain) == 0 {
+				r.Spec.Istio.Gateway.Domain = config.GetDefaultDomain()
+			}
 
 			// set default cert
 			if r.Spec.Istio.Gateway.Rest.TLS != nil && r.Spec.Istio.Gateway.Rest.TLS.Mode != DefaultTlsMode &&
@@ -159,6 +172,9 @@ func (r *ModelRegistry) Default() {
 
 // ValidateRegistry validates registry spec
 func (r *ModelRegistry) ValidateRegistry() (warnings admission.Warnings, err error) {
+	// set runtime defaults before validation, just like the reconcile loop
+	r.RuntimeDefaults()
+
 	warnings, errList := r.ValidateDatabase()
 	warn, errList2 := r.ValidateIstioConfig()
 

--- a/config/crd/bases/modelregistry.opendatahub.io_modelregistries.yaml
+++ b/config/crd/bases/modelregistry.opendatahub.io_modelregistries.yaml
@@ -752,6 +752,10 @@ spec:
               hostsStr:
                 description: Formatted Host names separated by comma
                 type: string
+              specDefaults:
+                description: SpecDefaults is a JSON string containing default spec
+                  values that were used for model registry deployment
+                type: string
             type: object
         type: object
     served: true

--- a/internal/controller/modelregistry_controller.go
+++ b/internal/controller/modelregistry_controller.go
@@ -179,6 +179,9 @@ func (r *ModelRegistryReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, nil
 	}
 
+	// set runtime default properties in memory for reconciliation
+	modelRegistry.RuntimeDefaults()
+
 	// set defaults and validate if not using webhooks
 	if !r.EnableWebhooks {
 		modelRegistry.Default()
@@ -208,7 +211,7 @@ func (r *ModelRegistryReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	// set custom resource status
 	available := false
-	if available, err = r.setRegistryStatus(ctx, req, result); err != nil {
+	if available, err = r.setRegistryStatus(ctx, req, params, result); err != nil {
 		return r.handleReconcileErrors(ctx, modelRegistry, ctrl.Result{Requeue: true}, err)
 	}
 	log.Info("status reconciled")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Moved runtime default property values to spec status field json string `specDefaults`
The field is primarily for diagnostics to be able to troubleshoot operator behavior.
The generated resources (Deployments, etc.) are not affected by this change. 

Fixes RHOAIENG-15033

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Built and tested in local cluster, also existing envtest and CI tests should pass.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work