### PR TITLE
fix: cleanup runtime default properties on first reconcile, fixes RHOAIENG-15033

### DIFF
--- a/api/v1alpha1/modelregistry_webhook.go
+++ b/api/v1alpha1/modelregistry_webhook.go
@@ -23,11 +23,14 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"maps"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	"slices"
+	"strings"
 )
 
 // log is for logging in this package.
@@ -41,6 +44,9 @@ const (
 	DefaultTlsMode      = IstioMutualTlsMode
 	IstioMutualTlsMode  = "ISTIO_MUTUAL"
 	DefaultIstioGateway = "ingressgateway"
+
+	tagSeparator = ":"
+	emptyValue   = ""
 )
 
 func (r *ModelRegistry) SetupWebhookWithManager(mgr ctrl.Manager) error {
@@ -63,7 +69,7 @@ var (
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *ModelRegistry) Default() {
-	modelregistrylog.Info("default", "name", r.Name)
+	modelregistrylog.Info("default", "name", r.Name, "status.specDefaults", r.Status.SpecDefaults)
 
 	// handle annotation mutations
 	r.HandleAnnotations()
@@ -114,6 +120,89 @@ func (r *ModelRegistry) Default() {
 			}
 			if len(r.Spec.Istio.Gateway.Grpc.GatewayRoute) == 0 {
 				r.Spec.Istio.Gateway.Grpc.GatewayRoute = config.RouteEnabled
+			}
+		}
+	}
+
+	// handle runtime default properties for https://issues.redhat.com/browse/RHOAIENG-15033
+	r.cleanupRuntimeDefaults()
+}
+
+// cleanupRuntimeDefaults removes runtime defaults on first reconcile, when specDefaults is empty,
+// also including model registries reconciled by older operator versions before adding specDefaults support.
+// It removes images if they are the same as the operator defaults (ignoring version tag),
+// and it removes default runtime values that match default runtime properties set in the operator
+// since they are redundant as custom property values.
+func (r *ModelRegistry) cleanupRuntimeDefaults() {
+	if len(r.Status.SpecDefaults) != 0 {
+		// nothing to do as model registries with specDefaults set
+		// will only have custom properties set by users
+		return
+	}
+
+	// check grpc image against operator default grpc image repo
+	if len(r.Spec.Grpc.Image) != 0 {
+		defaultGrpcImage := config.GetStringConfigWithDefault(config.GrpcImage, config.DefaultGrpcImage)
+		defaultGrpcImageRepo := strings.Split(defaultGrpcImage, tagSeparator)[0]
+
+		grpcImageRepo := strings.Split(r.Spec.Grpc.Image, tagSeparator)[0]
+		if grpcImageRepo == defaultGrpcImageRepo {
+			modelregistrylog.V(4).Info("reset image", "grpc repo", grpcImageRepo)
+			// remove image altogether as the MR repo matches operator repo,
+			// so that future operator version upgrades don't have to handle a hardcoded default
+			r.Spec.Grpc.Image = emptyValue
+
+			// also reset resource requirements
+			r.Spec.Grpc.Resources = nil
+		}
+	}
+
+	// check rest image against operator default rest image repo
+	if len(r.Spec.Rest.Image) != 0 {
+		defaultRestImage := config.GetStringConfigWithDefault(config.RestImage, config.DefaultRestImage)
+		defaultRestImageRepo := strings.Split(defaultRestImage, tagSeparator)[0]
+
+		restImageRepo := strings.Split(r.Spec.Rest.Image, tagSeparator)[0]
+		if restImageRepo == defaultRestImageRepo {
+			modelregistrylog.V(4).Info("reset image", "rest repo", restImageRepo)
+			// remove image altogether as the MR repo matches operator repo,
+			// so that future operator version upgrades don't have to handle a hardcoded default
+			r.Spec.Rest.Image = emptyValue
+
+			// also reset resource requirements
+			r.Spec.Rest.Resources = nil
+		}
+	}
+
+	// reset istio defaults
+	if r.Spec.Istio != nil {
+		// reset default audiences
+		if len(r.Spec.Istio.Audiences) != 0 && slices.Equal(r.Spec.Istio.Audiences, config.GetDefaultAudiences()) {
+			r.Spec.Istio.Audiences = make([]string, 0)
+		}
+		// reset default authprovider
+		if r.Spec.Istio.AuthProvider == config.GetDefaultAuthProvider() {
+			r.Spec.Istio.AuthProvider = emptyValue
+		}
+		// reset default authconfig labels
+		if len(r.Spec.Istio.AuthConfigLabels) != 0 && maps.Equal(r.Spec.Istio.AuthConfigLabels, config.GetDefaultAuthConfigLabels()) {
+			r.Spec.Istio.AuthConfigLabels = make(map[string]string)
+		}
+
+		if r.Spec.Istio.Gateway != nil {
+			// reset default domain
+			if r.Spec.Istio.Gateway.Domain == config.GetDefaultDomain() {
+				r.Spec.Istio.Gateway.Domain = emptyValue
+			}
+
+			// reset default cert
+			if r.Spec.Istio.Gateway.Rest.TLS != nil && r.Spec.Istio.Gateway.Rest.TLS.Mode != DefaultTlsMode &&
+				(r.Spec.Istio.Gateway.Rest.TLS.CredentialName != nil && *r.Spec.Istio.Gateway.Rest.TLS.CredentialName == config.GetDefaultCert()) {
+				r.Spec.Istio.Gateway.Rest.TLS.CredentialName = nil
+			}
+			if r.Spec.Istio.Gateway.Grpc.TLS != nil && r.Spec.Istio.Gateway.Grpc.TLS.Mode != DefaultTlsMode &&
+				(r.Spec.Istio.Gateway.Grpc.TLS.CredentialName != nil && *r.Spec.Istio.Gateway.Grpc.TLS.CredentialName == config.GetDefaultCert()) {
+				r.Spec.Istio.Gateway.Grpc.TLS.CredentialName = nil
 			}
 		}
 	}

--- a/api/v1alpha1/modelregistry_webhook.go
+++ b/api/v1alpha1/modelregistry_webhook.go
@@ -134,7 +134,7 @@ func (r *ModelRegistry) Default() {
 // and it removes default runtime values that match default runtime properties set in the operator
 // since they are redundant as custom property values.
 func (r *ModelRegistry) cleanupRuntimeDefaults() {
-	if len(r.Status.SpecDefaults) != 0 {
+	if r.Status.SpecDefaults != "" && r.Status.SpecDefaults != "{}" {
 		// nothing to do as model registries with specDefaults set
 		// will only have custom properties set by users
 		return

--- a/internal/controller/modelregistry_controller_status.go
+++ b/internal/controller/modelregistry_controller_status.go
@@ -20,7 +20,7 @@ import (
 	"bufio"
 	"context"
 	"fmt"
-	jsonpatch "github.com/evanphx/json-patch/v5"
+	"github.com/evanphx/json-patch/v5"
 	"github.com/go-logr/logr"
 	authorino "github.com/kuadrant/authorino/api/v1beta2"
 	modelregistryv1alpha1 "github.com/opendatahub-io/model-registry-operator/api/v1alpha1"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Cleanup runtime default properties on first reconcile
Fixes RHOAIENG-15033

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally by using an MR with default runtime properties and verified that it gets cleaned up to remove them.

Create test MR using secure-db mysql-tls sample, then delete the test MR and wait for it to be completely removed. 

Recreate the MR with default runtime properties using the command:
```shell
# deletes old MR just to be safe
oc delete mr -n odh-model-registries modelregistry-sample
# create test MR with default values
oc apply -f - <<EOF
apiVersion: modelregistry.opendatahub.io/v1alpha1
kind: ModelRegistry
metadata:
  labels:
    app.kubernetes.io/created-by: model-registry-operator
    app.kubernetes.io/instance: modelregistry-sample
    app.kubernetes.io/managed-by: kustomize
    app.kubernetes.io/name: modelregistry
    app.kubernetes.io/part-of: model-registry-operator
  name: modelregistry-sample
  namespace: odh-model-registries
spec:
  grpc:
    image: quay.io/opendatahub/mlmd-grpc-server:latest
    port: 9090
    resources:
      limits:
        cpu: 100m
        memory: 256Mi
      requests:
        cpu: 100m
        memory: 256Mi
  istio:
    authProvider: opendatahub-auth-provider
    authConfigLabels:
      security.opendatahub.io/authorization-group: default
    gateway:
      grpc:
        gatewayRoute: enabled
        port: 443
        tls:
          credentialName: default-modelregistry-cert
          mode: SIMPLE
      istioIngress: ingressgateway
      rest:
        gatewayRoute: enabled
        port: 443
        tls:
          credentialName: default-modelregistry-cert
          mode: SIMPLE
    tlsMode: ISTIO_MUTUAL
  mysql:
    database: model_registry
    host: model-registry-db
    passwordSecret:
      key: database-password
      name: model-registry-db
    port: 3306
    skipDBCreation: false
    sslRootCertificateConfigMap:
      key: ca.crt
      name: model-registry-db-credential
    username: mlmduser
  rest:
    image: quay.io/opendatahub/model-registry:latest
    port: 8080
    serviceRoute: disabled
    resources:
      limits:
        cpu: 100m
        memory: 256Mi
      requests:
        cpu: 100m
        memory: 256Mi
EOF
```

After reconciliation with this fix, the default runtime property values including images should be removed from the above MR. 

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work