### PR TITLE
fix: fixed unexpected error logs from reading grpc container when it hasn't started, fixes RHOAIENG-15573

### DIFF
--- a/internal/controller/modelregistry_controller_status.go
+++ b/internal/controller/modelregistry_controller_status.go
@@ -65,7 +65,8 @@ const (
 	ReasonResourcesAvailable   = "ResourcesAvailable"
 	ReasonResourcesUnavailable = "ResourcesUnavailable"
 
-	grpcContainerName = "grpc-container"
+	grpcContainerName       = "grpc-container"
+	containerCreatingReason = "ContainerCreating"
 )
 
 // errRegexp is based on the CHECK_EQ macro output used by mlmd container.
@@ -231,8 +232,8 @@ func (r *ModelRegistryReconciler) CheckPodStatus(ctx context.Context, req ctrl.R
 		failedContainers := make(map[string]string)
 		for _, s := range p.Status.ContainerStatuses {
 			if !s.Ready {
-				// look for MLMD container errors
-				if s.Name == grpcContainerName {
+				// look for MLMD container errors, make sure it has also been created
+				if s.Name == grpcContainerName && s.State.Waiting != nil && s.State.Waiting.Reason != containerCreatingReason {
 					// check container log for MLMD errors
 					dbError, err := r.getGrpcContainerDBerror(ctx, p)
 					if err != nil {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixed unexpected error logs from reading grpc container when it hasn't started
Fixes RHOAIENG-15573

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested by recreating an MR and confirming that log doesn't contain unexpected errors.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work