### PR TITLE
fix: sync version in config/component_metadata.yaml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,11 +62,15 @@ help: ## Display this help.
 
 ##@ Development
 
+IMAGES_REST_VERSION=$(lastword $(subst :, ,${IMAGES_REST_SERVICE}))
 .PHONY: sync-images
 sync-images:
 	# sync model-registry image
 	sed "s|quay.io/opendatahub/model-registry:.*|${IMAGES_REST_SERVICE}|" -i ./config/manager/manager.yaml
 	sed "s|\"quay.io/opendatahub/model-registry:.*\"|\"${IMAGES_REST_SERVICE}\"|" -i ./internal/controller/config/defaults.go
+	# sync component_metadata.yaml model registry versions on line 6 and 9
+	sed -i "6s|: .*|: $(IMAGES_REST_VERSION)|" -i ./config/component_metadata.yaml
+	sed -i "9s|: .*|: $(IMAGES_REST_VERSION)|" -i ./config/component_metadata.yaml
 	# sync mlmd image
 	sed "s|quay.io/opendatahub/mlmd-grpc-server:.*|${IMAGES_GRPC_SERVICE}|" -i ./config/manager/manager.yaml
 	sed "s|\"quay.io/opendatahub/mlmd-grpc-server:.*\"|\"${IMAGES_GRPC_SERVICE}\"|" -i ./internal/controller/config/defaults.go

--- a/config/component_metadata.yaml
+++ b/config/component_metadata.yaml
@@ -3,8 +3,8 @@ releases:
     version: v1.14.0
     repoUrl: https://github.com/google/ml-metadata
   - name: Kubeflow Model Registry
-    version: v0.2.13
+    version: latest
     repoUrl: https://github.com/kubeflow/model-registry
   - name: Open Data Hub Model Registry Operator
-    version: v0.2.13
+    version: latest
     repoUrl: https://github.com/opendatahub-io/model-registry-operator


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Sync version in config/component_metadata.yaml with the image version from params.env

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Only changes yaml file version property.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work