### PR TITLE
feat: add securityContext to manifests

### DIFF
--- a/.github/workflows/build-image-pr.yml
+++ b/.github/workflows/build-image-pr.yml
@@ -61,4 +61,4 @@ jobs:
           ##debug
           #kubectl describe pods
           #kubectl logs -l name=model-registry-db || true
-          kubectl wait --for=condition=Available=true modelregistries/modelregistry-sample --timeout=5m
+          kubectl wait --for=condition=Available=true modelregistries/modelregistry-sample --timeout=5m || (kubectl describe mr; exit 1)

--- a/internal/controller/config/templates/deployment.yaml.tmpl
+++ b/internal/controller/config/templates/deployment.yaml.tmpl
@@ -34,6 +34,10 @@ spec:
         {{- end}}
         {{- end}}
     spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+        runAsNonRoot: true
       containers:
         - args:
             - --grpc_port={{.Spec.Grpc.Port}}
@@ -197,6 +201,13 @@ spec:
               cpu: {{.Spec.Grpc.Resources.Limits.Cpu}}
               memory: {{.Spec.Grpc.Resources.Limits.Memory}}
             {{- end }}
+          securityContext:
+            runAsUser: 65534
+            runAsGroup: 65534
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
         - args:
             - --hostname=0.0.0.0
             - --port={{.Spec.Rest.Port}}
@@ -233,6 +244,11 @@ spec:
               cpu: {{.Spec.Rest.Resources.Limits.Cpu}}
               memory: {{.Spec.Rest.Resources.Limits.Memory}}
             {{- end }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
       serviceAccountName: {{.Name}}
       volumes:
         {{- if .Spec.Postgres}}


### PR DESCRIPTION
## Description

Apply the `securityContext` settings from upstream PR [#768](https://github.com/kubeflow/model-registry/pull/768). This sets `seccompProfile`, forbids containers to run as root, and disables unnecessary system calls.

## How Has This Been Tested?
Verified that the settings were applied and checked MR functionality.

## Merge criteria:

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
