### PR TITLE
Remove dashboard devFlag from docs/install.md

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -198,11 +198,6 @@ spec:
     workbenches:
       managementState: Managed
     dashboard:
-      devFlags:
-        manifests:
-          - contextDir: manifests
-            sourcePath: ''
-            uri: 'https://github.com/mturley/odh-dashboard/tarball/custom-manifest-quay-main'
       managementState: Managed
     modelmeshserving:
       managementState: Managed


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When these instructions were written, the DSC used for reference had a devFlag in place for overriding the dashboard manifests. This isn't necessary.
<!--- Describe your changes in detail -->

## How Has This Been Tested?

N/A, markdown-only change
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
