### PR TITLE
chore: bump go to 1.22.12

### DIFF
--- a/.github/workflows/build-image-pr.yml
+++ b/.github/workflows/build-image-pr.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22.11'
+          go-version: '1.22.12'
       - name: Generate Tag
         shell: bash
         id: tags

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22.11'
+          go-version: '1.22.12'
       - name: Build
         run: make build
       - name: Check if there are uncommitted file changes

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/opendatahub-io/model-registry-operator
 
 go 1.22
 
-toolchain go1.22.11
+toolchain go1.22.12
 
 require (
 	github.com/banzaicloud/k8s-objectmatcher v1.8.0


### PR DESCRIPTION
## Description

Bump Go version to 1.22.12 in order to fix the build. I'm extracting this from #194. 

## How Has This Been Tested?

Build and sanity check.

## Merge criteria:

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
