### PR TITLE
fix(template): updated the gateway template label

### DIFF
--- a/internal/controller/config/templates/istio/gateway.yaml.tmpl
+++ b/internal/controller/config/templates/istio/gateway.yaml.tmpl
@@ -21,7 +21,7 @@ spec:
   selector:
     istio: {{.Spec.Istio.Gateway.IstioIngress}}
     {{- with .Spec.Istio.Gateway.ControlPlane}}
-    maistra.io/owner-name: {{.}}
+    istio.io/rev: {{.}}
     {{- end}}
   servers:
   - port:

--- a/internal/controller/modelregistry_controller.go
+++ b/internal/controller/modelregistry_controller.go
@@ -537,7 +537,7 @@ func (r *ModelRegistryReconciler) createOrUpdateGatewayRoutes(ctx context.Contex
 	var serviceList corev1.ServiceList
 	labels := client.MatchingLabels{"istio": *params.Spec.Istio.Gateway.IstioIngress}
 	if params.Spec.Istio.Gateway.ControlPlane != nil {
-		labels["maistra.io/owner-name"] = *params.Spec.Istio.Gateway.ControlPlane
+		labels["istio.io/rev"] = *params.Spec.Istio.Gateway.ControlPlane
 	}
 	if err = r.Client.List(ctx, &serviceList, labels); err != nil {
 		return result, err

--- a/internal/controller/modelregistry_controller_test.go
+++ b/internal/controller/modelregistry_controller_test.go
@@ -703,7 +703,7 @@ func validateRegistryIstio(ctx context.Context, typeNamespaceName types.Namespac
 		svc := corev1.Service{}
 		svc.Name = "istio"
 		svc.Namespace = typeNamespaceName.Namespace
-		svc.Labels = map[string]string{"istio": config.DefaultIstioIngressName, "maistra.io/owner-name": TestSmcp}
+		svc.Labels = map[string]string{"istio": config.DefaultIstioIngressName, "istio.io/rev": TestSmcp}
 		svc.Spec.Ports = []corev1.ServicePort{
 			{
 				Name:       "http2",

--- a/internal/controller/modelregistry_controller_test.go
+++ b/internal/controller/modelregistry_controller_test.go
@@ -48,7 +48,8 @@ import (
 )
 
 const DescriptionPrefix = "Test Registry "
-const TestSmcp = "test-smcp"
+
+var TestSmcp = "test-smcp"
 
 var _ = Describe("ModelRegistry controller", func() {
 
@@ -308,6 +309,7 @@ var _ = Describe("ModelRegistry controller", func() {
 						Grpc: v1alpha1.ServerConfig{
 							GatewayRoute: "enabled",
 						},
+						ControlPlane: &TestSmcp,
 					},
 				}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The label `maistra.io/owner-name` isn't propagated from the deployment to the pod `istio-ingressgateway`, so the selector failed in the istio Gateway, we choose to switch to the label `istio.io/rev` which is consistent across all related resources

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

tested on different clusters

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
