### PR TITLE
feat: validate registry namespace if a default namespace is set, fixes RHOAIENG-20962

### DIFF
--- a/api/v1alpha1/modelregistry_webhook_test.go
+++ b/api/v1alpha1/modelregistry_webhook_test.go
@@ -2,6 +2,7 @@ package v1alpha1_test
 
 import (
 	"fmt"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"reflect"
 	"testing"
 
@@ -21,6 +22,53 @@ var (
 	controlPlane   = "test-smcp"
 	istioIngress   = config.DefaultIstioIngressName
 )
+
+func TestValidateNamespace(t *testing.T) {
+	tests := []struct {
+		name                string
+		registriesNamespace string
+		registry            *v1alpha1.ModelRegistry
+		wantErr             bool
+	}{
+		{"empty registries namespace", "",
+			&v1alpha1.ModelRegistry{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "test-ns"},
+				Spec: v1alpha1.ModelRegistrySpec{
+					MySQL: &v1alpha1.MySQLConfig{},
+				}},
+			false},
+		{"valid registries namespace", "test-ns",
+			&v1alpha1.ModelRegistry{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "test-ns"},
+				Spec: v1alpha1.ModelRegistrySpec{
+					MySQL: &v1alpha1.MySQLConfig{},
+				}},
+			false},
+		{"invalid registries namespace", "test-ns",
+			&v1alpha1.ModelRegistry{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "not-test-ns"},
+				Spec: v1alpha1.ModelRegistrySpec{
+					MySQL: &v1alpha1.MySQLConfig{},
+				}},
+			true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config.SetRegistriesNamespace(tt.registriesNamespace)
+			errList := tt.registry.ValidateNamespace()
+			if tt.wantErr {
+				if len(errList) == 0 {
+					t.Errorf("ValidateNamespace() error = %v, wantErr %v", errList, tt.wantErr)
+				}
+			} else {
+				if len(errList) > 0 {
+					t.Errorf("ValidateNamespace() error = %v, wantErr %v", errList, tt.wantErr)
+				}
+			}
+			config.SetRegistriesNamespace("")
+		})
+	}
+}
 
 func TestValidateDatabase(t *testing.T) {
 	tests := []struct {

--- a/api/v1alpha1/modelregistry_webhook_test.go
+++ b/api/v1alpha1/modelregistry_webhook_test.go
@@ -56,6 +56,7 @@ func TestValidateNamespace(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			config.SetRegistriesNamespace(tt.registriesNamespace)
 			errList := tt.registry.ValidateNamespace()
+			config.SetRegistriesNamespace("")
 			if tt.wantErr {
 				if len(errList) == 0 {
 					t.Errorf("ValidateNamespace() error = %v, wantErr %v", errList, tt.wantErr)
@@ -65,7 +66,6 @@ func TestValidateNamespace(t *testing.T) {
 					t.Errorf("ValidateNamespace() error = %v, wantErr %v", errList, tt.wantErr)
 				}
 			}
-			config.SetRegistriesNamespace("")
 		})
 	}
 }

--- a/api/v1alpha1/webhook_suite_test.go
+++ b/api/v1alpha1/webhook_suite_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"github.com/opendatahub-io/model-registry-operator/internal/controller/config"
 	"net"
 	"path/filepath"
 	"runtime"
@@ -190,6 +191,17 @@ var _ = Describe("Model Registry validating webhook", func() {
 		}
 
 		Expect(k8sClient.Update(ctx, mr)).ShouldNot(Succeed())
+	})
+
+	It("Should not allow creating MR instance in a different namespace when registries namespace is set", func(ctx context.Context) {
+		config.SetRegistriesNamespace(namespaceBase)
+		mr := newModelRegistry(ctx, mrNameBase, namespaceBase)
+		Expect(k8sClient.Create(ctx, mr)).Should(Succeed())
+		Expect(k8sClient.Delete(ctx, mr)).Should(Succeed())
+
+		// use a different namespace
+		mr.Namespace = namespaceBase + "-invalid"
+		Expect(k8sClient.Create(ctx, mr)).ShouldNot(Succeed())
 	})
 })
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -187,7 +187,7 @@ func main() {
 	createAuthResources := os.Getenv(config.CreateAuthResources) != "false"
 	defaultDomain := os.Getenv(config.DefaultDomain)
 	defaultCert := os.Getenv(config.DefaultCert)
-	setupLog.Info("default registry config", config.DefaultDomain, defaultDomain, config.DefaultCert, defaultCert)
+	setupLog.Info("default registry config", config.RegistriesNamespace, registriesNamespace, config.DefaultDomain, defaultDomain, config.DefaultCert, defaultCert)
 
 	// default auth env variables
 	defaultAuthProvider := os.Getenv(config.DefaultAuthProvider)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -182,6 +182,7 @@ func main() {
 		os.Exit(1)
 	}
 
+	registriesNamespace := os.Getenv(config.RegistriesNamespace)
 	enableWebhooks := os.Getenv(config.EnableWebhooks) != "false"
 	createAuthResources := os.Getenv(config.CreateAuthResources) != "false"
 	defaultDomain := os.Getenv(config.DefaultDomain)
@@ -199,6 +200,7 @@ func main() {
 	setupLog.Info("default registry istio config", config.DefaultControlPlane, defaultControlPlane, config.DefaultIstioIngress, defaultIstioIngress)
 
 	// set default values for defaulting webhook
+	config.SetRegistriesNamespace(registriesNamespace)
 	config.SetDefaultDomain(defaultDomain, mgr.GetClient(), isOpenShift)
 	config.SetDefaultAudiences(tokenReview.Status.Audiences)
 	config.SetDefaultCert(defaultCert)

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -81,6 +81,8 @@ spec:
             value: "false"
           - name: CREATE_AUTH_RESOURCES
             value: "true"
+          - name: REGISTRIES_NAMESPACE
+            value: ""
           - name: DEFAULT_DOMAIN
             value: ""
           - name: DEFAULT_CERT

--- a/config/overlays/odh/params.env
+++ b/config/overlays/odh/params.env
@@ -3,3 +3,4 @@ IMAGES_GRPC_SERVICE=quay.io/opendatahub/mlmd-grpc-server:latest
 IMAGES_REST_SERVICE=quay.io/opendatahub/model-registry:latest
 CREATE_AUTH_RESOURCES=true
 DEFAULT_CERT=
+REGISTRIES_NAMESPACE=

--- a/config/overlays/odh/replacements.yaml
+++ b/config/overlays/odh/replacements.yaml
@@ -49,6 +49,16 @@
         name: controller-manager
       fieldPaths:
         - spec.template.spec.containers.[name=manager].env.[name=DEFAULT_CERT].value
+- source:
+    kind: ConfigMap
+    name: model-registry-operator-parameters
+    fieldPath: data.REGISTRIES_NAMESPACE
+  targets:
+    - select:
+        kind: Deployment
+        name: controller-manager
+      fieldPaths:
+        - spec.template.spec.containers.[name=manager].env.[name=REGISTRIES_NAMESPACE].value
 # Metrics service name replacements for auth proxy serving cert
 - source:
     kind: Service

--- a/internal/controller/config/defaults.go
+++ b/internal/controller/config/defaults.go
@@ -171,9 +171,11 @@ var (
 
 func SetRegistriesNamespace(namespace string) error {
 	namespace = strings.TrimSpace(namespace)
-	errs := validation.ValidateNamespaceName(namespace, false)
-	if len(errs) > 0 {
-		return fmt.Errorf("invalid registries namespace %s: %v", namespace, errs)
+	if len(namespace) != 0 {
+		errs := validation.ValidateNamespaceName(namespace, false)
+		if len(errs) > 0 {
+			return fmt.Errorf("invalid registries namespace %s: %v", namespace, errs)
+		}
 	}
 	defaultRegistriesNamespace = namespace
 	return nil

--- a/internal/controller/config/defaults.go
+++ b/internal/controller/config/defaults.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"embed"
 	"fmt"
+	"k8s.io/apimachinery/pkg/api/validation"
 	"strings"
 	"text/template"
 
@@ -46,6 +47,7 @@ const (
 	DefaultIstioIngressName = "ingressgateway"
 
 	// config env variables
+	RegistriesNamespace     = "REGISTRIES_NAMESPACE"
 	EnableWebhooks          = "ENABLE_WEBHOOKS"
 	CreateAuthResources     = "CREATE_AUTH_RESOURCES"
 	DefaultDomain           = "DEFAULT_DOMAIN"
@@ -57,13 +59,14 @@ const (
 )
 
 var (
-	defaultAuthConfigLabels map[string]string
-	defaultAuthProvider     = ""
-	defaultCert             = ""
-	defaultDomain           = ""
-	defaultAudiences        []string
-	defaultIstioIngress     = ""
-	defaultControlPlane     = ""
+	defaultAuthConfigLabels    map[string]string
+	defaultAuthProvider        = ""
+	defaultCert                = ""
+	defaultDomain              = ""
+	defaultAudiences           []string
+	defaultIstioIngress        = ""
+	defaultControlPlane        = ""
+	defaultRegistriesNamespace = ""
 
 	// Default ResourceRequirements
 	MlmdRestResourceRequirements = createResourceRequirement(resource.MustParse("100m"), resource.MustParse("256Mi"), resource.MustParse("100m"), resource.MustParse("256Mi"))
@@ -165,6 +168,20 @@ var (
 	defaultClient      client.Client
 	defaultIsOpenShift = false
 )
+
+func SetRegistriesNamespace(namespace string) error {
+	namespace = strings.TrimSpace(namespace)
+	errs := validation.ValidateNamespaceName(namespace, false)
+	if len(errs) > 0 {
+		return fmt.Errorf("invalid registries namespace %s: %v", namespace, errs)
+	}
+	defaultRegistriesNamespace = namespace
+	return nil
+}
+
+func GetRegistriesNamespace() string {
+	return defaultRegistriesNamespace
+}
 
 func SetDefaultDomain(domain string, client client.Client, isOpenShift bool) {
 	defaultDomain = domain

--- a/internal/controller/config/defaults_test.go
+++ b/internal/controller/config/defaults_test.go
@@ -190,6 +190,30 @@ func TestSetGetDefaultIstioIngress(t *testing.T) {
 	}
 }
 
+func TestSetRegistriesNamespace(t *testing.T) {
+	type args struct {
+		namespace string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{"valid namespace", args{"valid-namespace"}, false},
+		{"invalid namespace", args{"invalid//namespace"}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := config.SetRegistriesNamespace(tt.args.namespace); (err != nil) != tt.wantErr {
+				t.Errorf("SetRegistriesNamespace() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if res := config.GetRegistriesNamespace(); !tt.wantErr && res != tt.args.namespace {
+				t.Errorf("GetRegistriesNamespace() expected %s, received %s", tt.args.namespace, res)
+			}
+		})
+	}
+}
+
 var _ = Describe("Defaults integration tests", func() {
 	Describe("TestSetGetDefaultDomain", func() {
 		It("Should return the set domain on openshift", func() {

--- a/internal/controller/config/defaults_test.go
+++ b/internal/controller/config/defaults_test.go
@@ -199,6 +199,7 @@ func TestSetRegistriesNamespace(t *testing.T) {
 		args    args
 		wantErr bool
 	}{
+		{"empty namespace", args{""}, false},
 		{"valid namespace", args{"valid-namespace"}, false},
 		{"invalid namespace", args{"invalid//namespace"}, true},
 	}

--- a/internal/controller/config/defaults_test.go
+++ b/internal/controller/config/defaults_test.go
@@ -210,6 +210,7 @@ func TestSetRegistriesNamespace(t *testing.T) {
 			if res := config.GetRegistriesNamespace(); !tt.wantErr && res != tt.args.namespace {
 				t.Errorf("GetRegistriesNamespace() expected %s, received %s", tt.args.namespace, res)
 			}
+			config.SetRegistriesNamespace("")
 		})
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Validate registry namespace if a default namespace is set in the env variable REGISTRIES_NAMESPACE
Fixes RHOAIENG-20962

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added unit tests for env variable and webhook

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work