### PR TITLE
fix: fix security context constrainst config, fixes RHOAIENG-13857

### DIFF
--- a/internal/controller/config/templates/deployment.yaml.tmpl
+++ b/internal/controller/config/templates/deployment.yaml.tmpl
@@ -26,7 +26,7 @@ spec:
         component: model-registry
         sidecar.istio.io/inject: {{with .Spec.Istio}}"true"{{else}}"false"{{end}}
       annotations:
-        openshift.io/required-scc: restricted
+        openshift.io/required-scc: restricted-v2
         {{- if .Spec.Istio}}
         {{- if .Spec.Postgres}}
         traffic.sidecar.istio.io/excludeOutboundPorts: {{.Spec.Postgres.Port}}
@@ -203,8 +203,7 @@ spec:
               memory: {{.Spec.Grpc.Resources.Limits.Memory}}
             {{- end }}
           securityContext:
-            runAsUser: 65534
-            runAsGroup: 65534
+            runAsNonRoot: true
             allowPrivilegeEscalation: false
             capabilities:
               drop:
@@ -246,6 +245,7 @@ spec:
               memory: {{.Spec.Rest.Resources.Limits.Memory}}
             {{- end }}
           securityContext:
+            runAsNonRoot: true
             allowPrivilegeEscalation: false
             capabilities:
               drop:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix security context constrainst config to use restricted-v2 scc, and use runAsNonRoot instead of specific ui and gid
Fixes RHOAIENG-13857

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work