### PR TITLE
fix: remove fixed runAsUser and runAsGroup, fixes RHOAIENG-21954

### DIFF
--- a/.github/workflows/build-image-pr.yml
+++ b/.github/workflows/build-image-pr.yml
@@ -56,6 +56,13 @@ jobs:
         run: |
           kubectl apply -k config/samples/postgres/
           kubectl describe mr
+      - name: Patch Test Registry Deployment for Kind SecurityContext missing userid in mlmd
+        run: |
+          kubectl wait --for=condition=Progressing=True deployment/modelregistry-sample --timeout=5m
+          # patch mlmd container for Kind
+          kubectl patch deployment/modelregistry-sample --type='json' \
+            -p='[{"op":"add","path":"/spec/template/spec/containers/0/securityContext", \
+            "value":{"runAsUser":65534,"runAsGroup":65534}}]' || (kubectl describe mr; exit 1)
       - name: Wait for Test Registry Deployment
         run: |
           ##debug

--- a/.github/workflows/build-image-pr.yml
+++ b/.github/workflows/build-image-pr.yml
@@ -61,10 +61,10 @@ jobs:
           kubectl wait --for=condition=Progressing=True deployment/modelregistry-sample --timeout=5m
           # patch mlmd container for Kind
           kubectl patch deployment/modelregistry-sample --type='json' \
-            -p='[{"op":"add","path":"/spec/template/spec/containers/0/securityContext/runAsUser","value":65534}]' \
+            -p='[{"op":"add","path":"/spec/template/spec/containers/0/securityContext/runAsUser","value":1000860000}]' \
             || (kubectl describe deployment/modelregistry-sample; exit 1)
           kubectl patch deployment/modelregistry-sample --type='json' \
-            -p='[{"op":"add","path":"/spec/template/spec/containers/0/securityContext/runAsGroup","value":65534}]' \
+            -p='[{"op":"add","path":"/spec/template/spec/containers/0/securityContext/runAsGroup","value":1000860000}]' \
             || (kubectl describe deployment/modelregistry-sample; exit 1)
       - name: Wait for Test Registry Deployment
         run: |

--- a/.github/workflows/build-image-pr.yml
+++ b/.github/workflows/build-image-pr.yml
@@ -61,8 +61,11 @@ jobs:
           kubectl wait --for=condition=Progressing=True deployment/modelregistry-sample --timeout=5m
           # patch mlmd container for Kind
           kubectl patch deployment/modelregistry-sample --type='json' \
-            -p='[{"op":"add","path":"/spec/template/spec/containers/0/securityContext", \
-            "value":{"runAsUser":65534,"runAsGroup":65534}}]' || (kubectl describe mr; exit 1)
+            -p='[{"op":"add","path":"/spec/template/spec/containers/0/securityContext/runAsUser","value":65534}]' \
+            || (kubectl describe deployment/modelregistry-sample; exit 1)
+          kubectl patch deployment/modelregistry-sample --type='json' \
+            -p='[{"op":"add","path":"/spec/template/spec/containers/0/securityContext/runAsGroup","value":65534}]' \
+            || (kubectl describe deployment/modelregistry-sample; exit 1)
       - name: Wait for Test Registry Deployment
         run: |
           ##debug

--- a/internal/controller/config/templates/deployment.yaml.tmpl
+++ b/internal/controller/config/templates/deployment.yaml.tmpl
@@ -203,8 +203,6 @@ spec:
               memory: {{.Spec.Grpc.Resources.Limits.Memory}}
             {{- end }}
           securityContext:
-            runAsUser: 1000860000
-            runAsGroup: 1000860000
             allowPrivilegeEscalation: false
             capabilities:
               drop:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Remove fixed runAsUser and runAsGroup
Fix Kind cluster testing to set missing ids in mlmd image for now
Fixes RHOAIENG-21954

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
CI should validate Kind patch, removing ids was tested manually in OpenShift

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work