### PR TITLE
fix: use a new URL for the route.openshift.io/v1 CRD

### DIFF
--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -18,11 +18,12 @@ package controller
 
 import (
 	"fmt"
-	networkingscheme "k8s.io/api/networking/v1"
 	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
+
+	networkingscheme "k8s.io/api/networking/v1"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -71,7 +72,7 @@ var (
 			fileName: "istio.yaml",
 		},
 		{
-			url:      "https://raw.githubusercontent.com/openshift/api/refs/heads/master/route/v1/zz_generated.crd-manifests/routes-Default.crd.yaml",
+			url:      "https://raw.githubusercontent.com/openshift/api/e7ac40fc1590efe8697d76691aa644d1ec3f07a7/route/v1/zz_generated.crd-manifests/routes.crd.yaml",
 			fileName: "route.openshift.io_routes.yaml",
 		},
 	}

--- a/internal/utils/io.go
+++ b/internal/utils/io.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -13,6 +14,10 @@ func DownloadFile(url string, path string) error {
 	}
 
 	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("unable to fetch %q: %s", url, resp.Status)
+	}
 
 	file, err := os.Create(path)
 	if err != nil {


### PR DESCRIPTION
## Description

The old file was [removed](https://github.com/openshift/api/pull/2268/files#diff-a8396022e5cbcaddf0147a4917b3f1e4c1ee21f32e053c96bff72d83a0c33192).

## How Has This Been Tested?
Running the tests

## Merge criteria:

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
