### PR TITLE
chore: Remove CPU limits

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -114,10 +114,9 @@ spec:
         # More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
         resources:
           limits:
-            cpu: 500m
             memory: 256Mi
           requests:
-            cpu: 10m
+            cpu: 100m
             memory: 256Mi
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10

--- a/internal/controller/config/defaults.go
+++ b/internal/controller/config/defaults.go
@@ -20,9 +20,10 @@ import (
 	"context"
 	"embed"
 	"fmt"
-	"k8s.io/apimachinery/pkg/api/validation"
 	"strings"
 	"text/template"
+
+	"k8s.io/apimachinery/pkg/api/validation"
 
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/spf13/viper"
@@ -72,8 +73,8 @@ var (
 	defaultRegistriesNamespace = ""
 
 	// Default ResourceRequirements
-	MlmdRestResourceRequirements = createResourceRequirement(resource.MustParse("100m"), resource.MustParse("256Mi"), resource.MustParse("100m"), resource.MustParse("256Mi"))
-	MlmdGRPCResourceRequirements = createResourceRequirement(resource.MustParse("100m"), resource.MustParse("256Mi"), resource.MustParse("100m"), resource.MustParse("256Mi"))
+	MlmdRestResourceRequirements = createResourceRequirement(resource.MustParse("100m"), resource.MustParse("256Mi"), resource.MustParse("0m"), resource.MustParse("256Mi"))
+	MlmdGRPCResourceRequirements = createResourceRequirement(resource.MustParse("100m"), resource.MustParse("256Mi"), resource.MustParse("0m"), resource.MustParse("256Mi"))
 )
 
 func init() {

--- a/internal/controller/config/templates/deployment.yaml.tmpl
+++ b/internal/controller/config/templates/deployment.yaml.tmpl
@@ -191,17 +191,19 @@ spec:
             tcpSocket:
               port: grpc-api
             timeoutSeconds: 2
+          {{- with .Spec.Grpc.Resources }}
           resources:
-            {{- if .Spec.Grpc.Resources.Requests }}
+            {{- with .Requests }}
             requests:
-              cpu: {{.Spec.Grpc.Resources.Requests.Cpu}}
-              memory: {{.Spec.Grpc.Resources.Requests.Memory}}
+              cpu: {{.Cpu}}
+              memory: {{.Memory}}
             {{- end }}
-            {{- if .Spec.Grpc.Resources.Limits }}
+            {{- with .Limits }}
             limits:
-              cpu: {{.Spec.Grpc.Resources.Limits.Cpu}}
-              memory: {{.Spec.Grpc.Resources.Limits.Memory}}
+              {{ if not .Cpu.IsZero }}cpu: {{.Cpu}}{{ end }}
+              memory: {{.Memory}}
             {{- end }}
+          {{- end }}
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -232,17 +234,19 @@ spec:
             tcpSocket:
               port: http-api
             timeoutSeconds: 2
+          {{- with .Spec.Rest.Resources }}
           resources:
-            {{- if .Spec.Rest.Resources.Requests }}
+            {{- with .Requests }}
             requests:
-              cpu: {{.Spec.Rest.Resources.Requests.Cpu}}
-              memory: {{.Spec.Rest.Resources.Requests.Memory}}
+              cpu: {{.Cpu}}
+              memory: {{.Memory}}
             {{- end }}
-            {{- if .Spec.Rest.Resources.Limits }}
+            {{- with .Limits }}
             limits:
-              cpu: {{.Spec.Rest.Resources.Limits.Cpu}}
-              memory: {{.Spec.Rest.Resources.Limits.Memory}}
+              {{ if not .Cpu.IsZero }}cpu: {{.Cpu}}{{ end }}
+              memory: {{.Memory}}
             {{- end }}
+          {{- end }}
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -287,7 +291,6 @@ spec:
             failureThreshold: 3
           resources:
             limits:
-              cpu: 100m
               memory: 256Mi
             requests:
               cpu: 100m


### PR DESCRIPTION
## Description
Remove CPU limits from the operator deployment ([RHOAIENG-23177](https://issues.redhat.com/browse/RHOAIENG-23177)).

## How Has This Been Tested?
Automated tests, and verified that the limit was removed from on my dev cluster:

```
$ oc get pod -l component=model-registry -o=jsonpath='{.items[*].spec.containers[].resources.limits}' ; echo
{"memory":"256Mi"}
```

And that the pod was still up:

```
$ oc get pod -l component=model-registry
NAME                                    READY   STATUS    RESTARTS   AGE
modelregistry-public-7647c45c94-gt8sb   3/3     Running   0          7m33s
```

## Merge criteria:

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

## Summary by Sourcery

Remove CPU resource limits for model registry components and the controller manager.

Deployment:
- Remove the CPU limit for the controller manager and increase its CPU request.
- Remove the default CPU limits for the MLMD REST and gRPC server deployments.