### PR TITLE
fix: support deploying model registry without servicemesh feature, fixes RHOAIENG-25242

### DIFF
--- a/config/overlays/odh/patches/manager_auth_config_patch.yaml
+++ b/config/overlays/odh/patches/manager_auth_config_patch.yaml
@@ -18,9 +18,11 @@ spec:
                 # used in the istio servicemeshcontrolplane (smcp) config
                 key: AUTH_NAMESPACE
                 name: auth-refs
+                optional: true
           - name: DEFAULT_AUTH_CONFIG_LABELS
             valueFrom:
               configMapKeyRef:
                 # AUTHORINO_LABEL has the label selector for authorino
                 key: AUTHORINO_LABEL
                 name: auth-refs
+                optional: true

--- a/config/overlays/odh/patches/manager_istio_config_patch.yaml
+++ b/config/overlays/odh/patches/manager_istio_config_patch.yaml
@@ -17,6 +17,7 @@ spec:
                 # CONTROL_PLANE_NAME has the name of the istio smcp
                 key: CONTROL_PLANE_NAME
                 name: service-mesh-refs
+                optional: true
           - name: DEFAULT_ISTIO_INGRESS
             valueFrom:
               configMapKeyRef:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Support deploying model registry without servicemesh feature
Fixes RHOAIENG-25242
Requires making servicemesh config map dependencies optional in the ODH manifest.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated deployment configuration to allow certain environment variables to be optional, improving deployment resilience when related configuration keys are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->