### PR TITLE
fix(oauth-proxy): silence cookie signature log message

### DIFF
--- a/internal/controller/config/templates/deployment.yaml.tmpl
+++ b/internal/controller/config/templates/deployment.yaml.tmpl
@@ -262,6 +262,7 @@ spec:
             - --tls-cert=/etc/tls/private-cert/{{.Spec.OAuthProxy.TLSCertificateSecret.Key}}
             - --tls-key=/etc/tls/private-key/{{.Spec.OAuthProxy.TLSKeySecret.Key}}
             - --cookie-secret=MODEL_REGISTRY_OAUTH_SECRET
+            - --cookie-name=_{{.Name}}_oauth_proxy
             - '--openshift-delegate-urls={"/":{"group":"","resource":"services","verb":"get","name":"{{.Name}}","namespace":"{{.Namespace}}"}}'
             - --skip-auth-regex='(^/metrics|^/oauth/healthz)'
           image: {{.Spec.OAuthProxy.Image}}


### PR DESCRIPTION
## Description
Requests from the dashboard go through a different OAuth Proxy instance with a different secret, so those requests generated a error saying that the signature was invalid. This change uses a unique cookie name to avoid triggering the error.

@dhirajsb, this should fix the error from [here](https://issues.redhat.com/browse/RHOAIENG-23194?focusedId=27196028&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-27196028).

## How Has This Been Tested?
- Enabling oauth-proxy in a dev cluster, observing the error, and verified it no longer occur after the fix.
- Basic sanity check on API requests (curl and in the dashboard). 

## Merge criteria:
- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
