### PR TITLE
add status for schema migrate fail

### DIFF
--- a/internal/controller/modelregistry_controller_status.go
+++ b/internal/controller/modelregistry_controller_status.go
@@ -355,6 +355,12 @@ func (r *ModelRegistryReconciler) getContainerDBerror(ctx context.Context, pod c
 	scanner := bufio.NewScanner(podLogs)
 	for scanner.Scan() {
 		line := scanner.Text()
+
+		// priority check for alert errors
+		if strings.Contains(line, "{{ALERT}}") {
+			return fmt.Errorf("%s", line), nil
+		}
+		// then check for generic errors
 		submatch := errRegexp.FindStringSubmatch(line)
 		if len(submatch) > 0 {
 			return fmt.Errorf("%s: %s", submatch[2], submatch[1]), nil


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add a new status update when the mr db rest-container pod logs schema migration errors. User must manually fix the error and status updates will help in identification of the problem.

## How Has This Been Tested?
This was tested by deploying local changes to the ODH operator, setting the schema_migrations table dirty value to true, and checking the status on the odh dashboard. See screenshot:

<img width="1082" alt="Screenshot 2025-06-26 at 5 40 24 PM" src="https://github.com/user-attachments/assets/4d5c452b-6eff-4aa1-8e93-e48e58d8fa92" />

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced error detection in pod status checks by scanning logs from both "grpc-container" and "rest-container" for alert patterns.
  * Immediate status updates and alert messages are now provided when specific alerts are detected in container logs.

* **Bug Fixes**
  * Improved handling of configuration and alert errors for more accurate pod status reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->