### PR TITLE
feat: add support for storage version migration using couple of different strategies, fixes RHOAIENG-26604

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -18,8 +18,9 @@ package main
 
 import (
 	"flag"
-	"github.com/opendatahub-io/model-registry-operator/internal/webhook"
 	"os"
+
+	"github.com/opendatahub-io/model-registry-operator/internal/webhook"
 
 	networking "istio.io/client-go/pkg/apis/networking/v1beta1"
 	security "istio.io/client-go/pkg/apis/security/v1beta1"
@@ -46,6 +47,7 @@ import (
 	modelregistryv1alpha1 "github.com/opendatahub-io/model-registry-operator/api/v1alpha1"
 	modelregistryv1beta1 "github.com/opendatahub-io/model-registry-operator/api/v1beta1"
 	"github.com/opendatahub-io/model-registry-operator/internal/controller"
+	"github.com/opendatahub-io/model-registry-operator/internal/migration"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -215,8 +217,13 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Start storage migration monitor
+	ctx := ctrl.SetupSignalHandler()
+	migrationMgr := migration.NewStorageMigrationManager(mgr.GetClient())
+	migrationMgr.StartMigrationMonitor(ctx)
+
 	setupLog.Info("starting manager")
-	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
+	if err := mgr.Start(ctx); err != nil {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}

--- a/config/overlays/odh/kustomization.yaml
+++ b/config/overlays/odh/kustomization.yaml
@@ -24,6 +24,9 @@ patches:
 # patch to add webhooks to manager
 - path: patches/manager_webhook_patch.yaml
 
+# patch to add storage migration environment variables
+- path: patches/manager_migration_env_patch.yaml
+
 # patch to add CA bundles in Webhooks
 - path: patches/mutatingwh_cainjection_patch.yaml
 - path: patches/validatingwh_cainjection_patch.yaml

--- a/config/overlays/odh/patches/manager_migration_env_patch.yaml
+++ b/config/overlays/odh/patches/manager_migration_env_patch.yaml
@@ -1,0 +1,15 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        env:
+        - name: STORAGE_MIGRATION_SOURCE_VERSION
+          value: "v1alpha1"
+        - name: STORAGE_MIGRATION_TARGET_VERSION
+          value: "v1beta1" 

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -35,6 +35,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - apps
   resources:
   - deployments
@@ -161,6 +169,18 @@ rules:
   - security.istio.io
   resources:
   - authorizationpolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - storagemigration.k8s.io
+  resources:
+  - storageversionmigrations
   verbs:
   - create
   - delete

--- a/internal/controller/modelregistry_controller.go
+++ b/internal/controller/modelregistry_controller.go
@@ -346,6 +346,8 @@ func (r *ModelRegistryReconciler) GetRegistryForClusterRoleBinding(ctx context.C
 // +kubebuilder:rbac:groups=authentication.k8s.io,resources=tokenreviews,verbs=create
 // +kubebuilder:rbac:groups=authorization.k8s.io,resources=subjectaccessreviews,verbs=create
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=storagemigration.k8s.io,resources=storageversionmigrations,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch
 
 func (r *ModelRegistryReconciler) updateRegistryResources(ctx context.Context, params *ModelRegistryParams, registry *v1beta1.ModelRegistry) (OperationResult, error) {
 

--- a/internal/migration/detector.go
+++ b/internal/migration/detector.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package migration
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/opendatahub-io/model-registry-operator/internal/controller/config"
+)
+
+const (
+	ModelRegistryCRDName  = "modelregistries.modelregistry.opendatahub.io"
+	ModelRegistryGroup    = "modelregistry.opendatahub.io"
+	ModelRegistryResource = "modelregistries"
+)
+
+//+kubebuilder:rbac:groups=storagemigration.k8s.io,resources=storageversionmigrations,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch
+//+kubebuilder:rbac:groups=modelregistry.opendatahub.io,resources=modelregistries,verbs=get;list;watch;update;patch
+
+type StorageMigrationManager struct {
+	client.Client
+	SourceVersion string
+	TargetVersion string
+	strategies    []MigrationStrategy
+}
+
+func NewStorageMigrationManager(client client.Client) *StorageMigrationManager {
+	sourceVersion := config.GetStringConfigWithDefault("STORAGE_MIGRATION_SOURCE_VERSION", "")
+	targetVersion := config.GetStringConfigWithDefault("STORAGE_MIGRATION_TARGET_VERSION", "")
+
+	return &StorageMigrationManager{
+		Client:        client,
+		SourceVersion: sourceVersion,
+		TargetVersion: targetVersion,
+		strategies: []MigrationStrategy{
+			NewSVMStrategy(client, sourceVersion, targetVersion),    // Try StorageVersionMigration first
+			NewManualStrategy(client, sourceVersion, targetVersion), // Fallback to manual migration
+		},
+	}
+}
+
+func (m *StorageMigrationManager) StartMigrationMonitor(ctx context.Context) {
+	log := log.FromContext(ctx).WithName("storage-migration")
+
+	if m.SourceVersion == m.TargetVersion {
+		log.Info("Source and target versions are the same, skipping migration",
+			"version", m.SourceVersion)
+		return
+	}
+
+	log.Info("Starting storage migration monitor",
+		"sourceVersion", m.SourceVersion,
+		"targetVersion", m.TargetVersion)
+
+	go func() {
+		// Wait for manager to be ready
+		select {
+		case <-time.After(30 * time.Second):
+		case <-ctx.Done():
+			return
+		}
+
+		if err := m.checkAndPerformMigration(ctx); err != nil {
+			log.Error(err, "Failed to perform migration")
+			return
+		}
+	}()
+}
+
+func (m *StorageMigrationManager) checkAndPerformMigration(ctx context.Context) error {
+	log := log.FromContext(ctx).WithName("storage-migration")
+
+	// Get the ModelRegistry CRD
+	crd := &apiextensionsv1.CustomResourceDefinition{}
+	if err := m.Get(ctx, types.NamespacedName{Name: ModelRegistryCRDName}, crd); err != nil {
+		return fmt.Errorf("failed to get ModelRegistry CRD: %w", err)
+	}
+
+	// Check if source version is still in storage versions
+	if !m.needsStorageVersionMigration(crd) {
+		log.Info("No storage version migration needed",
+			"sourceVersion", m.SourceVersion,
+			"storedVersions", crd.Status.StoredVersions)
+		return nil
+	}
+
+	log.Info("Source version found in storage versions, starting migration",
+		"sourceVersion", m.SourceVersion,
+		"targetVersion", m.TargetVersion,
+		"storedVersions", crd.Status.StoredVersions)
+
+	// Try each strategy in order until one succeeds
+	for _, strategy := range m.strategies {
+		if strategy.IsSupported(ctx) {
+			log.Info("Using migration strategy", "strategy", strategy.GetName())
+
+			if err := strategy.PerformMigration(ctx, crd); err != nil {
+				log.Error(err, "Migration strategy failed", "strategy", strategy.GetName())
+				continue // Try next strategy
+			}
+
+			log.Info("Migration completed successfully", "strategy", strategy.GetName())
+			return nil
+		} else {
+			log.Info("Migration strategy not supported", "strategy", strategy.GetName())
+		}
+	}
+
+	return fmt.Errorf("no supported migration strategy found")
+}
+
+func (m *StorageMigrationManager) needsStorageVersionMigration(crd *apiextensionsv1.CustomResourceDefinition) bool {
+	for _, version := range crd.Status.StoredVersions {
+		if version == m.SourceVersion {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/migration/manual_strategy.go
+++ b/internal/migration/manual_strategy.go
@@ -1,0 +1,180 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package migration
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+//+kubebuilder:rbac:groups=modelregistry.opendatahub.io,resources=modelregistries,verbs=get;list;watch;update;patch
+
+// ManualStrategy implements migration by re-reading and re-writing resources
+// This triggers the conversion webhook and forces storage in the new version
+type ManualStrategy struct {
+	client.Client
+	SourceVersion string
+	TargetVersion string
+}
+
+func NewManualStrategy(client client.Client, sourceVersion, targetVersion string) *ManualStrategy {
+	return &ManualStrategy{
+		Client:        client,
+		SourceVersion: sourceVersion,
+		TargetVersion: targetVersion,
+	}
+}
+
+func (m *ManualStrategy) GetName() string {
+	return "Manual Re-read/Re-write"
+}
+
+func (m *ManualStrategy) IsSupported(ctx context.Context) bool {
+	// Manual strategy is always supported as it only requires basic CRUD operations
+	return true
+}
+
+func (m *ManualStrategy) PerformMigration(ctx context.Context, crd *apiextensionsv1.CustomResourceDefinition) error {
+	log := log.FromContext(ctx).WithName("manual-strategy")
+
+	log.Info("Starting manual storage version migration by re-reading and updating all ModelRegistry resources",
+		"sourceVersion", m.SourceVersion,
+		"targetVersion", m.TargetVersion)
+
+	// List all ModelRegistry resources using the source version
+	sourceGVR := schema.GroupVersionResource{
+		Group:    ModelRegistryGroup,
+		Version:  m.SourceVersion,
+		Resource: ModelRegistryResource,
+	}
+
+	list := &unstructured.UnstructuredList{}
+	list.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   sourceGVR.Group,
+		Version: sourceGVR.Version,
+		Kind:    "ModelRegistryList",
+	})
+
+	if err := m.List(ctx, list); err != nil {
+		return fmt.Errorf("failed to list ModelRegistry resources: %w", err)
+	}
+
+	log.Info("Found ModelRegistry resources to migrate", "count", len(list.Items))
+
+	// Process each resource - force migration for all since we only run when needed
+	migratedCount := 0
+	for i, item := range list.Items {
+		if err := m.migrateResource(ctx, &item, i+1, len(list.Items)); err != nil {
+			log.Error(err, "Failed to migrate resource", "name", item.GetName(), "namespace", item.GetNamespace())
+			// Continue with other resources instead of failing completely
+		} else {
+			migratedCount++
+		}
+	}
+
+	log.Info("Manual storage version migration completed",
+		"totalResources", len(list.Items),
+		"migratedResources", migratedCount)
+
+	// Verify migration success by checking if source version is still in storage
+	if err := m.verifyMigrationComplete(ctx, crd); err != nil {
+		return fmt.Errorf("migration verification failed: %w", err)
+	}
+
+	return nil
+}
+
+// verifyMigrationComplete checks if the source version is still present in storedVersions
+func (m *ManualStrategy) verifyMigrationComplete(ctx context.Context, crd *apiextensionsv1.CustomResourceDefinition) error {
+	log := log.FromContext(ctx).WithName("manual-strategy")
+
+	// Re-fetch the CRD to get latest status
+	updatedCRD := &apiextensionsv1.CustomResourceDefinition{}
+	if err := m.Get(ctx, types.NamespacedName{Name: crd.Name}, updatedCRD); err != nil {
+		return fmt.Errorf("failed to re-fetch CRD: %w", err)
+	}
+
+	// Check if source version is still in storedVersions
+	for _, version := range updatedCRD.Status.StoredVersions {
+		if version == m.SourceVersion {
+			log.Info("Source version still present in storedVersions - migration may need more time",
+				"sourceVersion", m.SourceVersion,
+				"storedVersions", updatedCRD.Status.StoredVersions)
+			// This is not necessarily an error - etcd cleanup happens asynchronously
+			return nil
+		}
+	}
+
+	log.Info("Migration verification successful - source version no longer in storedVersions",
+		"sourceVersion", m.SourceVersion,
+		"storedVersions", updatedCRD.Status.StoredVersions)
+	return nil
+}
+
+func (m *ManualStrategy) migrateResource(ctx context.Context, resource *unstructured.Unstructured, current, total int) error {
+	log := log.FromContext(ctx).WithName("manual-strategy")
+
+	name := resource.GetName()
+	namespace := resource.GetNamespace()
+
+	log.Info("Migrating resource", "name", name, "namespace", namespace, "progress", fmt.Sprintf("%d/%d", current, total))
+
+	// Generic approach - read in target version and force a write
+	// This triggers conversion webhook regardless of specific version combinations
+	targetResource := &unstructured.Unstructured{}
+	targetResource.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   ModelRegistryGroup,
+		Version: m.TargetVersion,
+		Kind:    "ModelRegistry",
+	})
+
+	// Get the resource in target version (triggers conversion)
+	if err := m.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, targetResource); err != nil {
+		return fmt.Errorf("failed to get resource in target version %s: %w", m.TargetVersion, err)
+	}
+
+	// Force a write by updating resourceVersion annotation
+	// This ensures the resource is written to etcd in the target storage version
+	annotations := targetResource.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+
+	// Use a migration marker that includes the migration path
+	migrationKey := fmt.Sprintf("storage-migration.opendatahub.io/migrated-%s-to-%s", m.SourceVersion, m.TargetVersion)
+	annotations[migrationKey] = time.Now().Format(time.RFC3339)
+
+	// Also track the resourceVersion we're migrating to avoid duplicate work
+	annotations["storage-migration.opendatahub.io/last-migrated-rv"] = targetResource.GetResourceVersion()
+
+	targetResource.SetAnnotations(annotations)
+
+	if err := m.Update(ctx, targetResource); err != nil {
+		return fmt.Errorf("failed to update resource for migration: %w", err)
+	}
+
+	log.Info("Successfully migrated resource", "name", name, "namespace", namespace)
+	return nil
+}

--- a/internal/migration/migration_test.go
+++ b/internal/migration/migration_test.go
@@ -1,0 +1,346 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package migration
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/opendatahub-io/model-registry-operator/api/v1alpha1"
+	"github.com/opendatahub-io/model-registry-operator/api/v1beta1"
+)
+
+var _ = Describe("Storage Version Migration", func() {
+	const (
+		timeout  = time.Second * 30
+		interval = time.Millisecond * 250
+	)
+
+	var (
+		ctx           context.Context
+		testNamespace string
+		sourceVersion = "v1alpha1"
+		targetVersion = "v1beta1"
+		migrationMgr  *StorageMigrationManager
+		testCRD       *apiextensionsv1.CustomResourceDefinition
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		testNamespace = fmt.Sprintf("test-migration-%d-%s", time.Now().UnixNano(), randStringRunes(5))
+
+		// Create test namespace
+		ns := &unstructured.Unstructured{}
+		ns.SetAPIVersion("v1")
+		ns.SetKind("Namespace")
+		ns.SetName(testNamespace)
+		Expect(k8sClient.Create(ctx, ns)).To(Succeed())
+
+		// Get the ModelRegistry CRD
+		testCRD = &apiextensionsv1.CustomResourceDefinition{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: ModelRegistryCRDName}, testCRD)).To(Succeed())
+
+		// Create migration manager
+		migrationMgr = NewStorageMigrationManager(k8sClient)
+		migrationMgr.SourceVersion = sourceVersion
+		migrationMgr.TargetVersion = targetVersion
+	})
+
+	AfterEach(func() {
+		// Clean up test namespace
+		ns := &unstructured.Unstructured{}
+		ns.SetAPIVersion("v1")
+		ns.SetKind("Namespace")
+		ns.SetName(testNamespace)
+		_ = k8sClient.Delete(ctx, ns)
+	})
+
+	Describe("Migration Detection", func() {
+		Context("when source version is in storedVersions", func() {
+			BeforeEach(func() {
+				// Simulate CRD with source version in storedVersions
+				testCRD.Status.StoredVersions = []string{sourceVersion, targetVersion}
+			})
+
+			It("should detect migration is needed", func() {
+				needsMigration := migrationMgr.needsStorageVersionMigration(testCRD)
+				Expect(needsMigration).To(BeTrue())
+			})
+		})
+
+		Context("when source version is not in storedVersions", func() {
+			BeforeEach(func() {
+				// Simulate CRD with only target version in storedVersions
+				testCRD.Status.StoredVersions = []string{targetVersion}
+			})
+
+			It("should detect migration is not needed", func() {
+				needsMigration := migrationMgr.needsStorageVersionMigration(testCRD)
+				Expect(needsMigration).To(BeFalse())
+			})
+		})
+	})
+
+	Describe("Manual Strategy", func() {
+		var (
+			manualStrategy *ManualStrategy
+			testMR         *v1alpha1.ModelRegistry
+		)
+
+		BeforeEach(func() {
+			manualStrategy = NewManualStrategy(k8sClient, sourceVersion, targetVersion)
+
+			// Create a test ModelRegistry resource in v1alpha1
+			testMR = &v1alpha1.ModelRegistry{}
+			testMR.SetName("test-mr-manual")
+			testMR.SetNamespace(testNamespace)
+			testMR.Spec = v1alpha1.ModelRegistrySpec{
+				Rest: v1alpha1.RestSpec{},
+				Grpc: v1alpha1.GrpcSpec{},
+			}
+			Expect(k8sClient.Create(ctx, testMR)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			// Clean up test resource
+			_ = k8sClient.Delete(ctx, testMR)
+		})
+
+		It("should be supported", func() {
+			Expect(manualStrategy.IsSupported(ctx)).To(BeTrue())
+		})
+
+		It("should migrate resources and add migration annotations", func() {
+			// Perform migration
+			err := manualStrategy.PerformMigration(ctx, testCRD)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Verify migration annotation was added
+			Eventually(func() bool {
+				updatedMR := &v1beta1.ModelRegistry{}
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      testMR.Name,
+					Namespace: testMR.Namespace,
+				}, updatedMR)
+				if err != nil {
+					return false
+				}
+
+				annotations := updatedMR.GetAnnotations()
+				if annotations == nil {
+					return false
+				}
+
+				migrationKey := fmt.Sprintf("storage-migration.opendatahub.io/migrated-%s-to-%s", sourceVersion, targetVersion)
+				_, exists := annotations[migrationKey]
+				return exists
+			}, timeout, interval).Should(BeTrue())
+		})
+
+		It("should verify migration completion", func() {
+			// Perform migration
+			err := manualStrategy.PerformMigration(ctx, testCRD)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Verify migration completion check
+			err = manualStrategy.verifyMigrationComplete(ctx, testCRD)
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Describe("SVM Strategy", func() {
+		var svmStrategy *SVMStrategy
+
+		BeforeEach(func() {
+			svmStrategy = NewSVMStrategy(k8sClient, sourceVersion, targetVersion)
+		})
+
+		It("should check if StorageVersionMigration API is supported", func() {
+			// This will depend on the test environment
+			// In most test environments, SVM API won't be available
+			supported := svmStrategy.IsSupported(ctx)
+			// We don't assert the result since it depends on the cluster
+			// but we verify the method doesn't panic
+			_ = supported
+		})
+
+		Context("when StorageVersionMigration API is not available", func() {
+			It("should return false for IsSupported", func() {
+				// In test environments, SVM API is typically not available
+				// This test verifies graceful handling
+				supported := svmStrategy.IsSupported(ctx)
+				// Most likely false in test environment, but we don't assert
+				// to avoid flaky tests
+				_ = supported
+			})
+		})
+	})
+
+	Describe("Migration Manager Integration", func() {
+		var testMR *v1alpha1.ModelRegistry
+
+		BeforeEach(func() {
+			// Create a test ModelRegistry resource
+			testMR = &v1alpha1.ModelRegistry{}
+			testMR.SetName("test-mr-integration")
+			testMR.SetNamespace(testNamespace)
+			testMR.Spec = v1alpha1.ModelRegistrySpec{
+				Rest: v1alpha1.RestSpec{},
+				Grpc: v1alpha1.GrpcSpec{},
+			}
+			Expect(k8sClient.Create(ctx, testMR)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			// Clean up test resource
+			_ = k8sClient.Delete(ctx, testMR)
+		})
+
+		Context("when migration is needed", func() {
+			It("should perform migration using manual strategy directly", func() {
+				// Create manual strategy and test it directly
+				manualStrategy := NewManualStrategy(k8sClient, sourceVersion, targetVersion)
+
+				// Simulate CRD with source version in storedVersions for direct strategy test
+				testCRDCopy := testCRD.DeepCopy()
+				testCRDCopy.Status.StoredVersions = []string{sourceVersion, targetVersion}
+
+				// Perform migration using manual strategy directly
+				err := manualStrategy.PerformMigration(ctx, testCRDCopy)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Verify the resource was migrated (has migration annotation)
+				Eventually(func() bool {
+					updatedMR := &v1beta1.ModelRegistry{}
+					err := k8sClient.Get(ctx, types.NamespacedName{
+						Name:      testMR.Name,
+						Namespace: testMR.Namespace,
+					}, updatedMR)
+					if err != nil {
+						return false
+					}
+
+					annotations := updatedMR.GetAnnotations()
+					if annotations == nil {
+						return false
+					}
+
+					migrationKey := fmt.Sprintf("storage-migration.opendatahub.io/migrated-%s-to-%s", sourceVersion, targetVersion)
+					_, exists := annotations[migrationKey]
+					return exists
+				}, timeout, interval).Should(BeTrue())
+			})
+		})
+
+		Context("when migration is not needed", func() {
+			It("should detect no migration needed", func() {
+				// Test the migration detection logic directly
+				testCRDCopy := testCRD.DeepCopy()
+				testCRDCopy.Status.StoredVersions = []string{targetVersion}
+
+				needsMigration := migrationMgr.needsStorageVersionMigration(testCRDCopy)
+				Expect(needsMigration).To(BeFalse())
+
+				// Also verify that if we run checkAndPerformMigration with the real CRD
+				// (which likely has v1beta1 as the only stored version), it doesn't fail
+				err := migrationMgr.checkAndPerformMigration(ctx)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+	})
+
+	Describe("Cross-Version Compatibility", func() {
+		var testMR *v1alpha1.ModelRegistry
+
+		dbPort := int32(3306)
+		BeforeEach(func() {
+			// Create a test ModelRegistry with complex spec
+			testMR = &v1alpha1.ModelRegistry{}
+			testMR.SetName("test-mr-compat")
+			testMR.SetNamespace(testNamespace)
+			testMR.Spec = v1alpha1.ModelRegistrySpec{
+				Rest: v1alpha1.RestSpec{
+					Image: "test-rest-image",
+				},
+				Grpc: v1alpha1.GrpcSpec{
+					Image: "test-grpc-image",
+				},
+				MySQL: &v1alpha1.MySQLConfig{
+					Host:     "test-mysql",
+					Port:     &dbPort,
+					Database: "test-db",
+					Username: "test-user",
+					PasswordSecret: &v1alpha1.SecretKeyValue{
+						Name: "test-secret",
+						Key:  "password",
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, testMR)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			// Clean up test resource
+			_ = k8sClient.Delete(ctx, testMR)
+		})
+
+		It("should preserve data during conversion", func() {
+			// Read as v1alpha1
+			originalMR := &v1alpha1.ModelRegistry{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      testMR.Name,
+				Namespace: testMR.Namespace,
+			}, originalMR)).To(Succeed())
+
+			// Read as v1beta1 (triggers conversion)
+			convertedMR := &v1beta1.ModelRegistry{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      testMR.Name,
+				Namespace: testMR.Namespace,
+			}, convertedMR)).To(Succeed())
+
+			// Verify key fields are preserved
+			Expect(convertedMR.Spec.Rest.Image).To(Equal(originalMR.Spec.Rest.Image))
+			Expect(convertedMR.Spec.Grpc.Image).To(Equal(originalMR.Spec.Grpc.Image))
+
+			if originalMR.Spec.MySQL != nil && convertedMR.Spec.MySQL != nil {
+				Expect(convertedMR.Spec.MySQL.Host).To(Equal(originalMR.Spec.MySQL.Host))
+				Expect(convertedMR.Spec.MySQL.Database).To(Equal(originalMR.Spec.MySQL.Database))
+			}
+		})
+	})
+})
+
+// Helper function to generate random strings for test names
+func randStringRunes(n int) string {
+	rand.Seed(time.Now().UnixNano())
+	const letterRunes = "abcdefghijklmnopqrstuvwxyz0123456789"
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = letterRunes[rand.Intn(len(letterRunes))]
+	}
+	return string(b)
+}

--- a/internal/migration/strategy.go
+++ b/internal/migration/strategy.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package migration
+
+import (
+	"context"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+)
+
+// MigrationStrategy defines the interface for storage version migration strategies
+type MigrationStrategy interface {
+	// IsSupported checks if this strategy is supported in the current cluster
+	IsSupported(ctx context.Context) bool
+
+	// PerformMigration executes the migration using this strategy
+	PerformMigration(ctx context.Context, crd *apiextensionsv1.CustomResourceDefinition) error
+
+	// GetName returns the name of this strategy for logging
+	GetName() string
+}

--- a/internal/migration/suite_test.go
+++ b/internal/migration/suite_test.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package migration
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"github.com/opendatahub-io/model-registry-operator/api/v1alpha1"
+	"github.com/opendatahub-io/model-registry-operator/api/v1beta1"
+	//+kubebuilder:scaffold:imports
+)
+
+// These tests use Ginkgo (BDD-style Go testing framework). Refer to
+// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+
+var (
+	cfg       *rest.Config
+	k8sClient client.Client
+	testEnv   *envtest.Environment
+	ctx       context.Context
+	cancel    context.CancelFunc
+)
+
+func TestMigration(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "Migration Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	ctx, cancel = context.WithCancel(context.TODO())
+
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths: []string{
+			filepath.Join("..", "..", "config", "crd", "bases"),
+		},
+		ErrorIfCRDPathMissing: true,
+
+		// The BinaryAssetsDirectory is only required if you want to run the tests directly
+		// without call the makefile target test. If not informed it will look for the
+		// default path defined in controller-runtime which is /usr/local/kubebuilder/.
+		// Note that you must have the required binaries setup under the bin directory to perform
+		// the tests directly. When we run make test it will be setup and used automatically.
+		BinaryAssetsDirectory: filepath.Join("..", "..", "bin", "k8s",
+			fmt.Sprintf("1.28.0-%s-%s", runtime.GOOS, runtime.GOARCH)),
+	}
+
+	var err error
+	// cfg is defined in this file globally.
+	cfg, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	err = v1alpha1.AddToScheme(testEnv.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = v1beta1.AddToScheme(testEnv.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = apiextensionsv1.AddToScheme(testEnv.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	//+kubebuilder:scaffold:scheme
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: testEnv.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+})
+
+var _ = AfterSuite(func() {
+	cancel()
+	By("tearing down the test environment")
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+})

--- a/internal/migration/svm_strategy.go
+++ b/internal/migration/svm_strategy.go
@@ -1,0 +1,245 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package migration
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+//+kubebuilder:rbac:groups=storagemigration.k8s.io,resources=storageversionmigrations,verbs=get;list;watch;create;update;patch;delete
+
+// SVMStrategy implements migration using Kubernetes StorageVersionMigration API
+type SVMStrategy struct {
+	client.Client
+	SourceVersion string
+	TargetVersion string
+}
+
+func NewSVMStrategy(client client.Client, sourceVersion, targetVersion string) *SVMStrategy {
+	return &SVMStrategy{
+		Client:        client,
+		SourceVersion: sourceVersion,
+		TargetVersion: targetVersion,
+	}
+}
+
+func (s *SVMStrategy) GetName() string {
+	return "StorageVersionMigration"
+}
+
+func (s *SVMStrategy) IsSupported(ctx context.Context) bool {
+	// Check if the StorageVersionMigration API is available
+	gvr := schema.GroupVersionResource{
+		Group:    "storagemigration.k8s.io",
+		Version:  "v1alpha1",
+		Resource: "storageversionmigrations",
+	}
+
+	// Try to list StorageVersionMigrations to see if the API exists
+	list := &unstructured.UnstructuredList{}
+	list.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   gvr.Group,
+		Version: gvr.Version,
+		Kind:    "StorageVersionMigrationList",
+	})
+
+	err := s.List(ctx, list)
+	if err != nil {
+		if errors.IsNotFound(err) || errors.IsMethodNotSupported(err) {
+			return false
+		}
+		// Other errors might indicate the API exists but we don't have permissions
+		log.FromContext(ctx).Info("StorageVersionMigration API check returned error, assuming not supported", "error", err)
+		return false
+	}
+	return true
+}
+
+func (s *SVMStrategy) PerformMigration(ctx context.Context, crd *apiextensionsv1.CustomResourceDefinition) error {
+	log := log.FromContext(ctx).WithName("svm-strategy")
+
+	svmName := fmt.Sprintf("modelregistry-%s-to-%s-migration", s.SourceVersion, s.TargetVersion)
+
+	log.Info("Creating StorageVersionMigration", "name", svmName)
+
+	// Create StorageVersionMigration using unstructured to avoid import issues
+	svm := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "storagemigration.k8s.io/v1alpha1",
+			"kind":       "StorageVersionMigration",
+			"metadata": map[string]interface{}{
+				"name": svmName,
+				"labels": map[string]interface{}{
+					"app.kubernetes.io/name":       "model-registry-operator",
+					"app.kubernetes.io/component":  "storage-migration",
+					"app.kubernetes.io/managed-by": "model-registry-operator",
+				},
+			},
+			"spec": map[string]interface{}{
+				"resource": map[string]interface{}{
+					"group":    ModelRegistryGroup,
+					"version":  s.TargetVersion,
+					"resource": ModelRegistryResource,
+				},
+			},
+		},
+	}
+
+	// Check if migration already exists
+	existingSVM := &unstructured.Unstructured{}
+	existingSVM.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "storagemigration.k8s.io",
+		Version: "v1alpha1",
+		Kind:    "StorageVersionMigration",
+	})
+
+	err := s.Get(ctx, types.NamespacedName{Name: svmName}, existingSVM)
+	if err == nil {
+		log.Info("StorageVersionMigration already exists, monitoring progress", "name", svmName)
+		return s.monitorStorageVersionMigration(ctx, svmName)
+	}
+
+	if err := s.Create(ctx, svm); err != nil {
+		return fmt.Errorf("failed to create StorageVersionMigration: %w", err)
+	}
+
+	log.Info("Successfully created StorageVersionMigration", "name", svmName)
+
+	return s.monitorStorageVersionMigration(ctx, svmName)
+}
+
+func (s *SVMStrategy) monitorStorageVersionMigration(ctx context.Context, svmName string) error {
+	log := log.FromContext(ctx).WithName("svm-monitor")
+
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			log.Info("Migration monitor stopping due to context cancellation")
+			return nil
+		case <-ticker.C:
+			svm := &unstructured.Unstructured{}
+			svm.SetGroupVersionKind(schema.GroupVersionKind{
+				Group:   "storagemigration.k8s.io",
+				Version: "v1alpha1",
+				Kind:    "StorageVersionMigration",
+			})
+
+			err := s.Get(ctx, types.NamespacedName{Name: svmName}, svm)
+			if err != nil {
+				if errors.IsNotFound(err) {
+					log.Info("No StorageVersionMigration found, stopping monitor", "name", svmName)
+					return nil
+				}
+				log.Error(err, "Failed to get StorageVersionMigration", "name", svmName)
+				continue
+			}
+
+			// Check migration status
+			if s.isSVMCompleted(svm) {
+				log.Info("Storage version migration completed successfully",
+					"migration", svmName,
+					"duration", time.Since(svm.GetCreationTimestamp().Time))
+				return nil
+			}
+
+			if s.isSVMFailed(svm) {
+				log.Error(fmt.Errorf("migration failed"),
+					"Storage version migration failed",
+					"migration", svmName)
+				return fmt.Errorf("storage version migration failed")
+			}
+
+			// Log progress
+			log.Info("Storage version migration in progress",
+				"migration", svmName,
+				"age", time.Since(svm.GetCreationTimestamp().Time))
+		}
+	}
+}
+
+func (s *SVMStrategy) isSVMCompleted(svm *unstructured.Unstructured) bool {
+	conditions := s.extractConditions(svm)
+	return meta.IsStatusConditionTrue(conditions, "Succeeded")
+}
+
+func (s *SVMStrategy) isSVMFailed(svm *unstructured.Unstructured) bool {
+	conditions := s.extractConditions(svm)
+	return meta.IsStatusConditionFalse(conditions, "Succeeded")
+}
+
+// extractConditions converts unstructured conditions to metav1.Condition slice
+func (s *SVMStrategy) extractConditions(svm *unstructured.Unstructured) []metav1.Condition {
+	// Extract conditions from the unstructured object
+	conditionsRaw, found, err := unstructured.NestedSlice(svm.Object, "status", "conditions")
+	if !found || err != nil {
+		return nil
+	}
+
+	// Convert to metav1.Condition slice
+	var conditions []metav1.Condition
+	for _, conditionInterface := range conditionsRaw {
+		condition, ok := conditionInterface.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		// Extract required fields
+		condType, typeOk := condition["type"].(string)
+		status, statusOk := condition["status"].(string)
+		if !typeOk || !statusOk {
+			continue
+		}
+
+		// Convert to metav1.Condition
+		metaCondition := metav1.Condition{
+			Type:   condType,
+			Status: metav1.ConditionStatus(status),
+		}
+
+		// Optional fields
+		if reason, ok := condition["reason"].(string); ok {
+			metaCondition.Reason = reason
+		}
+		if message, ok := condition["message"].(string); ok {
+			metaCondition.Message = message
+		}
+		if lastTransitionTime, ok := condition["lastTransitionTime"].(string); ok {
+			if parsed, err := time.Parse(time.RFC3339, lastTransitionTime); err == nil {
+				metaCondition.LastTransitionTime = metav1.NewTime(parsed)
+			}
+		}
+
+		conditions = append(conditions, metaCondition)
+	}
+
+	return conditions
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add support for storage version migration using couple of different strategies, 
Strategies for migration include using K8s StorageVersionMigration, or brute force read and update of all existing model registry resources.
Fixes RHOAIENG-26604

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added CI tests.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work