### PR TITLE
fix: wrong status for OAuth proxy

### DIFF
--- a/internal/controller/modelregistry_controller_status.go
+++ b/internal/controller/modelregistry_controller_status.go
@@ -104,16 +104,16 @@ func (r *ModelRegistryReconciler) setRegistryStatus(ctx context.Context, req ctr
 		}
 	}
 
-	status := metav1.ConditionTrue
+	status := metav1.ConditionFalse
 	reason := ReasonDeploymentCreated
 	message := "Deployment was successfully created"
 	switch operationResult {
 	case ResourceCreated:
-		status = metav1.ConditionFalse
+		status = metav1.ConditionTrue
 		reason = ReasonDeploymentCreating
 		message = "Creating deployment"
 	case ResourceUpdated:
-		status = metav1.ConditionFalse
+		status = metav1.ConditionTrue
 		reason = ReasonDeploymentUpdating
 		message = "Updating deployment"
 	case ResourceUnchanged:
@@ -380,7 +380,7 @@ func (r *ModelRegistryReconciler) SetOauthProxyCondition(ctx context.Context, re
 
 	if modelRegistry.Spec.OAuthProxy != nil {
 
-		// verify that Deployment pod has 3 containers including the oauth proxy
+		// verify that Deployment pod has 2 containers including the oauth proxy
 		name := req.NamespacedName
 		reason2 := ReasonResourcesCreated
 		message2 := "OAuth Proxy was successfully created"
@@ -453,9 +453,9 @@ func (r *ModelRegistryReconciler) CheckDeploymentPods(ctx context.Context, name 
 		return message, reason, status
 	}
 
-	// check that pods have 3 containers
+	// check that pods have 2 containers
 	for _, pod := range pods.Items {
-		if len(pod.Spec.Containers) != 3 {
+		if len(pod.Spec.Containers) != 2 {
 			message = fmt.Sprintf("%s proxy unavailable in Pod %s", proxyType, pod.Name)
 			reason = ReasonResourcesUnavailable
 			status = metav1.ConditionFalse

--- a/internal/controller/modelregistry_controller_test.go
+++ b/internal/controller/modelregistry_controller_test.go
@@ -364,10 +364,6 @@ func validateRegistryBase(ctx context.Context, typeNamespaceName types.Namespace
 				Name:  "model-registry-rest",
 				Image: config.DefaultRestImage,
 			},
-			{
-				Name:  "model-registry-grpc",
-				Image: config.DefaultGrpcImage,
-			},
 		}
 
 		// mock istio proxy container

--- a/internal/controller/modelregistry_controller_test.go
+++ b/internal/controller/modelregistry_controller_test.go
@@ -534,8 +534,8 @@ func validateRegistryBase(ctx context.Context, typeNamespaceName types.Namespace
 					To(Equal(name))
 				Expect(modelRegistry.Status.HostsStr).To(Equal(strings.Join(hosts, ",")))
 			}
-			if !meta.IsStatusConditionTrue(modelRegistry.Status.Conditions, ConditionTypeProgressing) {
-				return fmt.Errorf("Condition %s is not true", ConditionTypeProgressing)
+			if meta.IsStatusConditionTrue(modelRegistry.Status.Conditions, ConditionTypeProgressing) {
+				return fmt.Errorf("Condition %s is not false", ConditionTypeProgressing)
 			}
 			if !meta.IsStatusConditionTrue(modelRegistry.Status.Conditions, ConditionTypeAvailable) {
 				return fmt.Errorf("Condition %s is not true: %+v", ConditionTypeAvailable, modelRegistry.Status)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

![image (1)](https://github.com/user-attachments/assets/52071d9d-2582-4879-85cf-af76b3bdf084)

as shown in the screenshot, there two problems with the CR status

1. Progressing stays on True when the Deployment has been created
2. OAuth is unavailable even if the two containers are in running in the pod

![image (2)](https://github.com/user-attachments/assets/c3157ce9-aaaa-4d8c-8b18-c9d939931539)


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated deployment status handling to more accurately reflect resource creation and update states.
  * Adjusted validation logic to expect two containers in deployment pods instead of three, improving OAuth proxy presence checks.

* **Tests**
  * Updated test cases to align with the new expected container count and revised status condition logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->