### PR TITLE
ci: maint. AppArmor for MySQL in GHA, align Manifest

### DIFF
--- a/.github/workflows/build-image-pr.yml
+++ b/.github/workflows/build-image-pr.yml
@@ -46,6 +46,10 @@ jobs:
           IMG: "model-registry-operator:${{ steps.tags.outputs.tag }}"
         run: |
           kind load docker-image -n chart-testing ${IMG}
+      - name: Remove AppArmor profile for MySQL 8.x in KinD on GHA # same as Kubeflow CI/GHA
+        run: |
+          set -x
+          sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
       - name: Deploy Operator Image
         env:
           IMG_VERSION: ${{ steps.tags.outputs.tag }}

--- a/config/samples/mysql/mysql-db.yaml
+++ b/config/samples/mysql/mysql-db.yaml
@@ -96,7 +96,7 @@ items:
               command:
                 - /bin/bash
                 - -c
-                - mysqladmin -h 127.0.0.1 -P 3306 -u${MYSQL_USER} -p${MYSQL_ROOT_PASSWORD} ping
+                - mysqladmin -u${MYSQL_USER} -p${MYSQL_ROOT_PASSWORD} ping
             initialDelaySeconds: 15
             periodSeconds: 10
             timeoutSeconds: 5
@@ -109,7 +109,7 @@ items:
               command:
               - /bin/bash
               - -c
-              - mysql -h 127.0.0.1 -P 3306 -D ${MYSQL_DATABASE} -u${MYSQL_USER} -p${MYSQL_ROOT_PASSWORD} -e 'SELECT 1'
+              - mysql -D ${MYSQL_DATABASE} -u${MYSQL_USER} -p${MYSQL_ROOT_PASSWORD} -e 'SELECT 1'
             initialDelaySeconds: 10
             timeoutSeconds: 5
           securityContext:


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
- restore MySQL manifest pre- #261
- maintain AppArmor profile in order to be able to use MySQL in KinD in GHA, we adopted same solution in
upstream Kubeflow

## How Has This Been Tested?
locally (ie running KinD locally) the manifest for MySQL don't need this change; the AppArmor profile solution is used in GHA in upstream Kubeflow, opening this PR to confirm same solution can be applied here.

 
## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the GitHub Actions workflow to adjust security settings for MySQL in the testing environment.

* **Refactor**
  * Simplified the liveness and readiness probes for MySQL containers by removing explicit host and port parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->