### PR TITLE
fix: fix CRD api access and svm group, fixes RHOAIENG-29500

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -24,6 +24,7 @@ import (
 
 	networking "istio.io/client-go/pkg/apis/networking/v1beta1"
 	security "istio.io/client-go/pkg/apis/security/v1beta1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
@@ -65,6 +66,8 @@ func init() {
 	utilruntime.Must(security.AddToScheme(scheme))
 	// istio networking scheme
 	utilruntime.Must(networking.AddToScheme(scheme))
+	// CRD scheme
+	utilruntime.Must(apiextensionsv1.AddToScheme(scheme))
 
 	utilruntime.Must(modelregistryv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(modelregistryv1beta1.AddToScheme(scheme))

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -87,6 +87,18 @@ rules:
   - list
   - watch
 - apiGroups:
+  - migration.k8s.io
+  resources:
+  - storageversionmigrations
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - modelregistry.opendatahub.io
   resources:
   - modelregistries
@@ -169,18 +181,6 @@ rules:
   - security.istio.io
   resources:
   - authorizationpolicies
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - storagemigration.k8s.io
-  resources:
-  - storageversionmigrations
   verbs:
   - create
   - delete

--- a/internal/controller/modelregistry_controller.go
+++ b/internal/controller/modelregistry_controller.go
@@ -346,7 +346,7 @@ func (r *ModelRegistryReconciler) GetRegistryForClusterRoleBinding(ctx context.C
 // +kubebuilder:rbac:groups=authentication.k8s.io,resources=tokenreviews,verbs=create
 // +kubebuilder:rbac:groups=authorization.k8s.io,resources=subjectaccessreviews,verbs=create
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=storagemigration.k8s.io,resources=storageversionmigrations,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=migration.k8s.io,resources=storageversionmigrations,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch
 
 func (r *ModelRegistryReconciler) updateRegistryResources(ctx context.Context, params *ModelRegistryParams, registry *v1beta1.ModelRegistry) (OperationResult, error) {

--- a/internal/migration/detector.go
+++ b/internal/migration/detector.go
@@ -35,7 +35,7 @@ const (
 	ModelRegistryResource = "modelregistries"
 )
 
-//+kubebuilder:rbac:groups=storagemigration.k8s.io,resources=storageversionmigrations,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=migration.k8s.io,resources=storageversionmigrations,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch
 //+kubebuilder:rbac:groups=modelregistry.opendatahub.io,resources=modelregistries,verbs=get;list;watch;update;patch
 

--- a/internal/migration/svm_strategy.go
+++ b/internal/migration/svm_strategy.go
@@ -32,7 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-//+kubebuilder:rbac:groups=storagemigration.k8s.io,resources=storageversionmigrations,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=migration.k8s.io,resources=storageversionmigrations,verbs=get;list;watch;create;update;patch;delete
 
 // SVMStrategy implements migration using Kubernetes StorageVersionMigration API
 type SVMStrategy struct {
@@ -56,7 +56,7 @@ func (s *SVMStrategy) GetName() string {
 func (s *SVMStrategy) IsSupported(ctx context.Context) bool {
 	// Check if the StorageVersionMigration API is available
 	gvr := schema.GroupVersionResource{
-		Group:    "storagemigration.k8s.io",
+		Group:    "migration.k8s.io",
 		Version:  "v1alpha1",
 		Resource: "storageversionmigrations",
 	}
@@ -91,7 +91,7 @@ func (s *SVMStrategy) PerformMigration(ctx context.Context, crd *apiextensionsv1
 	// Create StorageVersionMigration using unstructured to avoid import issues
 	svm := &unstructured.Unstructured{
 		Object: map[string]interface{}{
-			"apiVersion": "storagemigration.k8s.io/v1alpha1",
+			"apiVersion": "migration.k8s.io/v1alpha1",
 			"kind":       "StorageVersionMigration",
 			"metadata": map[string]interface{}{
 				"name": svmName,
@@ -114,7 +114,7 @@ func (s *SVMStrategy) PerformMigration(ctx context.Context, crd *apiextensionsv1
 	// Check if migration already exists
 	existingSVM := &unstructured.Unstructured{}
 	existingSVM.SetGroupVersionKind(schema.GroupVersionKind{
-		Group:   "storagemigration.k8s.io",
+		Group:   "migration.k8s.io",
 		Version: "v1alpha1",
 		Kind:    "StorageVersionMigration",
 	})
@@ -148,7 +148,7 @@ func (s *SVMStrategy) monitorStorageVersionMigration(ctx context.Context, svmNam
 		case <-ticker.C:
 			svm := &unstructured.Unstructured{}
 			svm.SetGroupVersionKind(schema.GroupVersionKind{
-				Group:   "storagemigration.k8s.io",
+				Group:   "migration.k8s.io",
 				Version: "v1alpha1",
 				Kind:    "StorageVersionMigration",
 			})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix CRD api access by adding missing scheme
Fix svm group in Openshift
fixes RHOAIENG-29500

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested by running it manually in a test ROSA cluster that SVM is created correctly and transitions to a Successful status.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the API group for the StorageVersionMigration resource from "storagemigration.k8s.io" to "migration.k8s.io" across RBAC permissions, annotations, and resource definitions to ensure proper functionality and access control.

* **Chores**
  * Updated internal references and configuration to align with the correct Kubernetes API group for storage version migrations.
  * Enhanced compatibility by registering Kubernetes API extensions v1 scheme with the controller manager.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->