### PR TITLE
feat: enable model catalog by default

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -188,7 +188,7 @@ func main() {
 	config.SetRegistriesNamespace(registriesNamespace)
 	config.SetDefaultDomain(defaultDomain, mgr.GetClient(), isOpenShift)
 
-	enableModelCatalog := os.Getenv(config.EnableModelCatalog) == "true"
+	enableModelCatalog := os.Getenv(config.EnableModelCatalog) != "false"
 	setupLog.Info("model catalog config", config.EnableModelCatalog, enableModelCatalog)
 
 	if err = (&controller.ModelRegistryReconciler{


### PR DESCRIPTION
## Description
Enable the model catalog unless it's explicitly been disabled (`ENABLE_MODEL_CATALOG=false`).

## How Has This Been Tested?
On a dev cluster.

## Merge criteria:

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The model catalog feature is now enabled by default unless the related environment variable is explicitly set to "false". This makes it easier to activate the feature without needing to set the variable to "true".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->