### PR TITLE
feat: specialize template for S3 to OCI (KServe ModelCar)

### DIFF
--- a/config/jobs-async-upload/README.md
+++ b/config/jobs-async-upload/README.md
@@ -3,5 +3,5 @@ This OpenShift Template generates the Job 'async-upload' developed in: https://g
 Example generation
 
 ```sh
-oc process --local -f jobs-async-upload-template.yaml -p MODEL_SYNC_MODEL_ID=1 -p MODEL_SYNC_MODEL_VERSION_ID=3 -p MODEL_SYNC_MODEL_ARTIFACT_ID=6 -p MODEL_SYNC_REGISTRY_SERVER_ADDRESS=https://... -p MODEL_SYNC_REGISTRY_PORT=443 -p SOURCE_CONNECTION=my-s3-credentials -p DESTINATION_CONNECTION=my-oci-credentials -o yaml
+oc process --local -f jobs-async-upload-s3-to-oci-template.yaml -p MODEL_SYNC_MODEL_ID=1 -p MODEL_SYNC_MODEL_VERSION_ID=3 -p MODEL_SYNC_MODEL_ARTIFACT_ID=6 -p MODEL_SYNC_REGISTRY_SERVER_ADDRESS=https://... -p MODEL_SYNC_REGISTRY_PORT=443 -p SOURCE_CONNECTION=my-s3-credentials -p DESTINATION_CONNECTION=my-oci-credentials -p MODEL_SYNC_SOURCE_AWS_KEY=path/in/bucket -o yaml
 ```

--- a/config/jobs-async-upload/jobs-async-upload-s3-to-oci-template.yaml
+++ b/config/jobs-async-upload/jobs-async-upload-s3-to-oci-template.yaml
@@ -2,9 +2,9 @@
 apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
-  name: jobs-async-upload-template
+  name: jobs-async-upload-s3-to-oci-template
   annotations:
-    description: "Example OpenShift template for the Model Registry jobs/async-upload"
+    description: "Example OpenShift template for the Model Registry jobs/async-upload going from S3 to OCI (KServe ModelCar)"
 parameters:
   - name: JOB_IMAGE
     description: The container image for the Job
@@ -34,6 +34,9 @@ parameters:
     required: true
   - name: DESTINATION_CONNECTION
     description: "Name of the Connection resource for the Sink destination (e.g.: OCI)"
+    required: true
+  - name: MODEL_SYNC_SOURCE_AWS_KEY
+    description: The path in the S3 bucket
     required: true
 objects:
   - apiVersion: batch/v1
@@ -110,3 +113,7 @@ objects:
                   value: "${MODEL_SYNC_MODEL_VERSION_ID}"
                 - name: MODEL_SYNC_MODEL_ARTIFACT_ID
                   value: "${MODEL_SYNC_MODEL_ARTIFACT_ID}"
+                - name: MODEL_SYNC_SOURCE_S3_CREDENTIALS_PATH
+                  value: "/opt/creds/source"
+                - name: MODEL_SYNC_SOURCE_AWS_KEY
+                  value: "${MODEL_SYNC_SOURCE_AWS_KEY}"

--- a/config/jobs-async-upload/kustomization.yaml
+++ b/config/jobs-async-upload/kustomization.yaml
@@ -1,2 +1,2 @@
 resources:
-- jobs-async-upload-template.yaml
+- jobs-async-upload-s3-to-oci-template.yaml

--- a/config/overlays/odh/replacements.yaml
+++ b/config/overlays/odh/replacements.yaml
@@ -111,6 +111,6 @@
   targets:
     - select:
         kind: Template
-        name: jobs-async-upload-template
+        name: jobs-async-upload-s3-to-oci-template
       fieldPaths:
         - parameters.[name=JOB_IMAGE].value


### PR DESCRIPTION
## Description

followup to https://github.com/opendatahub-io/model-registry-operator/pull/289
for specializing the template, considering we need to pass the KEY (path in bucket) externally to the secret

<!--- Provide a general summary of your changes in the Title above -->


<!--- Describe your changes in detail -->


## How Has This Been Tested?

### Test 1

```sh
oc process --local -f jobs-async-upload-s3-to-oci-template.yaml -p MODEL_SYNC_MODEL_ID=1 -p MODEL_SYNC_MODEL_VERSION_ID=3 -p MODEL_SYNC_MODEL_ARTIFACT_ID=6 -p MODEL_SYNC_REGISTRY_SERVER_ADDRESS=https://... -p MODEL_SYNC_REGISTRY_PORT=443 -p SOURCE_CONNECTION=my-s3-credentials -p DESTINATION_CONNECTION=my-oci-credentials -p MODEL_SYNC_SOURCE_AWS_KEY=path/in/bucket -p JOB_IMAGE=quay.io/opendatahub/model-registry-job-async-upload:v0.2.22 -o yaml | oc apply -f -

```

### Test 2

with the following in params.env:

```
IMAGES_JOBS_ASYNC_UPLOAD=quay.io/opendatahub/model-registry-job-async-upload:v0.2.22
```

and with:

```
kustomize build overlays/odh
```

the resulting overlay results do include the intended substitutions:

```yaml
- description: The container image for the Job
  name: JOB_IMAGE
  required: true
  value: quay.io/opendatahub/model-registry-job-async-upload:v0.2.22
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
(sources the credential from the mounted Connection resource (ODH Connection) 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added S3-to-OCI async upload workflow support and a required parameter to specify the S3 object key.
  * Exposed an environment variable for the source credentials path and an env var for the provided S3 key.
* **Refactor**
  * Renamed the async upload template to reflect S3-to-OCI usage and updated configs to reference it.
* **Chores**
  * Removed deprecated environment variables no longer used.
* **Documentation**
  * Updated template description and README example to show the new template and parameter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->