### PR TITLE
add default model catalog template

### DIFF
--- a/internal/controller/config/templates/catalog/catalog-configmap.yaml.tmpl
+++ b/internal/controller/config/templates/catalog/catalog-configmap.yaml.tmpl
@@ -18,6 +18,5 @@ data:
       - name: Default Catalog
         id: default_catalog
         type: yaml
-        enabled: true
         properties:
           yamlCatalogPath: /default-catalog.yaml


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This PR adds a default model catalog. WIP **no actual models are loaded here yet**


## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * A default YAML-based catalog is preconfigured and enabled out of the box.
  * The catalog appears as “Default Catalog” (id: default_catalog) and points to /default-catalog.yaml, reducing setup steps for new environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->