### PR TITLE
Manual sync from main to stable-2.x

### DIFF
--- a/internal/controller/config/templates/catalog/catalog-default-catalog-configmap.yaml.tmpl
+++ b/internal/controller/config/templates/catalog/catalog-default-catalog-configmap.yaml.tmpl
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: "model-catalog-sources"
+  name: default-model-catalog
   namespace: {{.Namespace}}
   labels:
     app: {{.Name}}
@@ -13,10 +13,6 @@ metadata:
     app.kubernetes.io/part-of: model-registry
     app.kubernetes.io/managed-by: model-registry-operator
 data:
-  sources.yaml: |-
-    catalogs:
-      - name: Default Catalog
-        id: default_catalog
-        type: yaml
-        properties:
-          yamlCatalogPath: /default/default-catalog.yaml
+  default-catalog.yaml: |-
+      source: Default
+      models: []

--- a/internal/controller/config/templates/catalog/catalog-deployment.yaml.tmpl
+++ b/internal/controller/config/templates/catalog/catalog-deployment.yaml.tmpl
@@ -35,6 +35,9 @@ spec:
       - name: sources
         configMap:
           name: model-catalog-sources
+      - name: default-catalog
+        configMap:
+          name: default-model-catalog
       {{- if .Spec.OAuthProxy }}
       - name: oauth-proxy-tls
         secret:
@@ -91,6 +94,8 @@ spec:
           volumeMounts:
           - name: sources
             mountPath: /catalog
+          - name: default-catalog
+            mountPath: /default
         {{ if .Spec.OAuthProxy }}
         - name: oauth-proxy
           args:

--- a/internal/controller/modelcatalog_controller.go
+++ b/internal/controller/modelcatalog_controller.go
@@ -70,8 +70,17 @@ func (r *ModelCatalogReconciler) ensureCatalogResources(ctx context.Context) (ct
 		return ctrl.Result{}, err
 	}
 
-	// Create or update ConfigMap
+	// Create sources ConfigMap
 	result2, err := r.ensureConfigMapExists(ctx, params, "catalog-configmap.yaml.tmpl")
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if result2 != ResourceUnchanged {
+		result = result2
+	}
+
+	// Create default catalog configmap
+	result2, err = r.ensureConfigMapExists(ctx, params, "catalog-default-catalog-configmap.yaml.tmpl")
 	if err != nil {
 		return ctrl.Result{}, err
 	}


### PR DESCRIPTION
The image changes for the default catalog are not present in nightly builds. Adding the required file in the kubernetes resources.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
