### PR TITLE
fix(catalog): fix route annotations

### DIFF
--- a/internal/controller/config/templates/catalog/catalog-route.yaml.tmpl
+++ b/internal/controller/config/templates/catalog/catalog-route.yaml.tmpl
@@ -1,7 +1,7 @@
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
-  name: {{.Name}}-https
+  name: {{.Name}}-http{{ if .Spec.OAuthProxy }}s{{ end }}
   namespace: {{.Namespace}}
   labels:
     app: {{.Name}}


### PR DESCRIPTION
## Description

The controller created a duplicate route and network policy, only one of which was correct.

Also fixing the port number on the `routing.opendatahub.io/external-address-rest` annotation in the catalog service.

## How Has This Been Tested?

Deployed on a dev cluster and verified that the addresses in the route and service are working:

```
curl -H"Authorization: Bearer $(oc whoami -t)" https://$(oc get route -n odh-model-registries model-catalog-https -o 'jsonpath={.spec.host}')/api/model_catalog/v1alpha1/sources
```

```
curl -H"Authorization: Bearer $(oc whoami -t)" https://$(oc get svc -n odh-model-registries model-catalog -o 'jsonpath={.metadata.annotations.routing\.opendatahub\.io/external-address-rest}')/api/model_catalog/v1alpha1/sources
```

## Merge criteria:

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added configurable RoutePort for the OAuth proxy.
  - Route names now reflect protocol automatically (-http when OAuth proxy is disabled, -https when enabled).

- Refactor
  - Removed OpenShift-specific auto-provisioning of OAuth proxy routes and related network policy to streamline cross-platform behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->