### PR TITLE
docs: add link to KCS for OCP MySQL template

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -225,6 +225,10 @@ Model Registry currently requires MySQL database 8.0.3 or above to function corr
 > The `mysql_native_password` authentication plugin is required for the ML Metadata component to successfully connect to your database. `mysql_native_password` is disabled by default in MySQL 8.4 and later. If your database uses MySQL 8.4 or later, you must update your MySQL deployment to enable the `mysql_native_password` plugin. 
 > For more information about enabling the `mysql_native_password` plugin, see [Native Pluggable Authentication](https://dev.mysql.com/doc/refman/8.4/en/native-pluggable-authentication.html) in the MySQL documentation.
 
+> [!TIP]
+> If you are using the "OpenShift Container Platform (OCP) [MySQL template](https://github.com/sclorg/mysql-container/blob/master/8.0/root/usr/share/container-scripts/mysql/README.md)" from Developer > "+Add" > Developer Catalog > Database > MySQL, you will need to change `caching_sha2_password` to `mysql_native_password` for the user created during the template setup.
+> You can check for more details the following article: https://access.redhat.com/solutions/7128249.
+
 For "Development" or "NON-PRODUCTION" scenarios you can use following script to install MySQL database.
 
 Create `namespace` where you want to host the database


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds the KCS article for the OCP MySQL Template.

## How Has This Been Tested?
n/a, just docs update with link to detailed KB article.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a TIP advising users of the OpenShift Container Platform MySQL template to switch the user authentication plugin to mysql_native_password during setup for compatibility.
  * Provided the navigation steps to locate the template in the Developer Catalog and linked to the Red Hat article with detailed instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->