### PR TITLE
fix: fix catalog reconciliation to avoid reconcile storms, fixes RHOAIENG-34217

### DIFF
--- a/internal/controller/modelcatalog_controller.go
+++ b/internal/controller/modelcatalog_controller.go
@@ -14,6 +14,7 @@ import (
 	rbac "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -21,6 +22,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
@@ -50,6 +52,11 @@ type ModelCatalogParams struct {
 
 // Reconcile manages a single model catalog instance
 func (r *ModelCatalogReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	// Note: We ignore req.Name and req.Namespace since all watched objects
+	// are mapped to the same fixed reconcile request for deduplication.
+	// This prevents reconcile storms from multiple objects trying to update
+	// the same shared resources.
+
 	// If disabled, just clean up any old resources.
 	if !r.Enabled {
 		return r.cleanupCatalogResources(ctx)
@@ -470,14 +477,28 @@ func (r *ModelCatalogReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		return err
 	}
 
+	// Custom mapper that maps ALL watched objects to the same reconcile request
+	// This enables workqueue deduplication to prevent reconcile storms
+	mapToFixedCatalogRequest := handler.EnqueueRequestsFromMapFunc(
+		func(ctx context.Context, obj client.Object) []reconcile.Request {
+			return []reconcile.Request{{
+				NamespacedName: types.NamespacedName{
+					Name:      modelCatalogName,  // Always use "model-catalog"
+					Namespace: r.TargetNamespace, // Always use target namespace
+				},
+			}}
+		},
+	)
+
 	c, err := ctrl.NewControllerManagedBy(mgr).
 		Named("modelcatalog").
-		Watches(&appsv1.Deployment{}, &handler.EnqueueRequestForObject{}, builder.WithPredicates(labels)).
-		Watches(&corev1.ConfigMap{}, &handler.EnqueueRequestForObject{}, builder.WithPredicates(labels)).
-		Watches(&corev1.Secret{}, &handler.EnqueueRequestForObject{}, builder.WithPredicates(labels)).
-		Watches(&corev1.ServiceAccount{}, &handler.EnqueueRequestForObject{}, builder.WithPredicates(labels)).
-		Watches(&corev1.Service{}, &handler.EnqueueRequestForObject{}, builder.WithPredicates(labels)).
-		Watches(&rbac.ClusterRoleBinding{}, &handler.EnqueueRequestForObject{}, builder.WithPredicates(labels)).
+		// All watched resources now map to the same reconcile request for deduplication
+		Watches(&appsv1.Deployment{}, mapToFixedCatalogRequest, builder.WithPredicates(labels)).
+		Watches(&corev1.ConfigMap{}, mapToFixedCatalogRequest, builder.WithPredicates(labels)).
+		Watches(&corev1.Secret{}, mapToFixedCatalogRequest, builder.WithPredicates(labels)).
+		Watches(&corev1.ServiceAccount{}, mapToFixedCatalogRequest, builder.WithPredicates(labels)).
+		Watches(&corev1.Service{}, mapToFixedCatalogRequest, builder.WithPredicates(labels)).
+		Watches(&rbac.ClusterRoleBinding{}, mapToFixedCatalogRequest, builder.WithPredicates(labels)).
 		Build(r)
 	if err != nil {
 		return err
@@ -493,5 +514,5 @@ func (r *ModelCatalogReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			"app.kubernetes.io/created-by": "model-registry-operator",
 		},
 	}}} // object identity only; it need not exist
-	return c.Watch(&source.Channel{Source: ch}, &handler.EnqueueRequestForObject{})
+	return c.Watch(&source.Channel{Source: ch}, mapToFixedCatalogRequest)
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix catalog reconciliation to avoid reconcile storms by using a single model-catalog pseudo resource name in reconcile request
Fixes RHOAIENG-34217

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Ensures the model catalog initializes reliably at startup by triggering an initial reconciliation even if no events occur immediately.

- Refactor
  - Consolidates event handling so all related changes map to a single reconciliation target, preventing reconcile storms.
  - Adds deduplication of reconcile triggers to reduce redundant processing and lower resource usage during high-change periods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->