### PR TITLE
fix(catalog): add a role/rolebinding for the catalog

### DIFF
--- a/.github/workflows/build-image-pr.yml
+++ b/.github/workflows/build-image-pr.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23.8'
+          go-version: '1.24.7'
       - name: Generate Tag
         shell: bash
         id: tags

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23.8'
+          go-version: '1.24.7'
       - name: Build
         run: make build
       - name: Check if there are uncommitted file changes

--- a/internal/controller/config/templates/catalog/catalog-role.yaml.tmpl
+++ b/internal/controller/config/templates/catalog/catalog-role.yaml.tmpl
@@ -1,0 +1,30 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations:
+    openshift.io/display-name: Model catalog User
+    openshift.io/description: Can access model catalog
+  labels:
+    app: {{.Name}}
+    app.kubernetes.io/created-by: model-registry-operator
+    app.kubernetes.io/managed-by: model-registry-operator
+    app.kubernetes.io/name: {{.Name}}
+  name: {{.Name}}
+  namespace: {{.Namespace}}
+rules:
+- apiGroups:
+  - ""
+  resourceNames:
+  - {{.Name}}
+  resources:
+  - services
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resourceNames:
+  - {{.Name}}
+  resources:
+  - endpoints
+  verbs:
+  - get

--- a/internal/controller/config/templates/catalog/catalog-rolebinding.yaml.tmpl
+++ b/internal/controller/config/templates/catalog/catalog-rolebinding.yaml.tmpl
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{.Name}}-authenticated
+  namespace: {{.Namespace}}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{.Name}}
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:authenticated


### PR DESCRIPTION
## Description

Add a role and rolebinding for model catalog to allow all authenticated users to access the service.

## How Has This Been Tested?
Dev cluster and unit tests.

## Merge criteria:

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Grants authenticated users read access to the Model Catalog’s service and endpoints via namespace-scoped RBAC (Role & RoleBinding).
  - Automatically manages NetworkPolicy for the Model Catalog on OpenShift to ensure expected connectivity.
- Tests
  - Added controller tests validating creation and cleanup of RBAC and OpenShift-specific resources, improving deployment reliability.
- Chores
  - CI updated to use Go 1.24.7.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->