### PR TITLE
fix(catalog): set ownerReferences on created resources

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -77,6 +77,14 @@ rules:
   verbs:
   - create
 - apiGroups:
+  - components.platform.opendatahub.io
+  resources:
+  - modelregistries
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - config.openshift.io
   resources:
   - ingresses

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/spf13/viper v1.18.2
 	istio.io/client-go v1.20.3-0.20240116015948-bc198a253520
 	k8s.io/api v0.28.3
+	k8s.io/apiextensions-apiserver v0.28.3
 	k8s.io/apimachinery v0.28.3
 	k8s.io/client-go v0.28.3
 	sigs.k8s.io/controller-runtime v0.16.3
@@ -117,7 +118,6 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	istio.io/api v1.20.3-0.20240116015448-5563f7225778 // indirect
-	k8s.io/apiextensions-apiserver v0.28.3 // indirect
 	k8s.io/apiserver v0.28.3 // indirect
 	k8s.io/component-base v0.28.3 // indirect
 	k8s.io/klog/v2 v2.100.1 // indirect

--- a/internal/controller/modelregistry_controller.go
+++ b/internal/controller/modelregistry_controller.go
@@ -329,6 +329,7 @@ func (r *ModelRegistryReconciler) GetRegistryForClusterRoleBinding(ctx context.C
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=migration.k8s.io,resources=storageversionmigrations,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch
+// +kubebuilder:rbac:groups=components.platform.opendatahub.io,resources=modelregistries,verbs=get;list;watch
 
 func (r *ModelRegistryReconciler) updateRegistryResources(ctx context.Context, params *ModelRegistryParams, registry *v1beta1.ModelRegistry) (OperationResult, error) {
 


### PR DESCRIPTION
## Description

Set `ownerReferences` on resources created for model catalog so everything is cleaned up.

## How Has This Been Tested?

On a cluster with a scaled down opendatahub operator, delete the platform model registry CR: `oc delete modelregistries.components.platform.opendatahub.io default-modelregistry`. The expectation is that the deployment and related resources are removed.

## Merge criteria:

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added read access to Model Registries, enabling discovery and integration within the platform.

- Refactor
  - Standardized resource ownership to the main deployment, enabling reliable cascading cleanup and reducing orphaned resources during uninstall or updates.

- Tests
  - Expanded test coverage to verify correct ownership and cleanup behavior across environments.

- Chores
  - Updated dependencies to improve compatibility and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->