### PR TITLE
feat: Remove all ml-metadata references from codebase

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -9,4 +9,5 @@
 
     # Ignore specific database user
     '''database-user\s*:\s*"mlmduser"'''
+    '''database-user\s*:\s*"modelregistryuser"'''
   ]

--- a/Makefile
+++ b/Makefile
@@ -93,9 +93,6 @@ sync-images:
 	# sync component_metadata.yaml model registry versions on line 6 and 9
 	$(SED) $(SED_INPLACE) "6s|: .*|: $(IMAGES_REST_VERSION)|" ./config/component_metadata.yaml
 	$(SED) $(SED_INPLACE) "9s|: .*|: $(IMAGES_REST_VERSION)|" ./config/component_metadata.yaml
-	# sync mlmd image
-	$(SED) "s|quay.io/opendatahub/mlmd-grpc-server:.*|${IMAGES_GRPC_SERVICE}|" $(SED_INPLACE) ./config/manager/manager.yaml
-	$(SED) "s|\"quay.io/opendatahub/mlmd-grpc-server:.*\"|\"${IMAGES_GRPC_SERVICE}\"|" $(SED_INPLACE) ./internal/controller/config/defaults.go
 
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ make certificates/clean
 ```
 
 NOTE: The sample database secret `model-registry-db-credential` is created with the CA cert, server key and server cert. However, in production the model registry only needs a secret with the CA cert(s). The production database server will be configured with a secret containing the private key and server cert. 
-The sample certificates use a self-signed CA and does not do cert management like cert rotation, etc. Use your own certificate manager, e.g. https://cert-manager.io/ and create generic kubernetes secrets for REST, gRPC and database with the the keys `tls.key`, `tls.crt`, and `ca.crt`. 
+The sample certificates use a self-signed CA and does not do cert management like cert rotation, etc. Use your own certificate manager, e.g. https://cert-manager.io/ and create generic kubernetes secrets for REST and database with the the keys `tls.key`, `tls.crt`, and `ca.crt`.
 
 Install a model registry instance using **ONE** of the following commands:
 

--- a/api/v1alpha1/modelregistry_webhook.go
+++ b/api/v1alpha1/modelregistry_webhook.go
@@ -119,23 +119,6 @@ func (r *ModelRegistry) CleanupRuntimeDefaults() {
 		return
 	}
 
-	// check grpc image against operator default grpc image repo
-	if len(r.Spec.Grpc.Image) != 0 {
-		defaultGrpcImage := config.GetStringConfigWithDefault(config.GrpcImage, config.DefaultGrpcImage)
-		defaultGrpcImageRepo := strings.Split(defaultGrpcImage, tagSeparator)[0]
-
-		grpcImageRepo := strings.Split(r.Spec.Grpc.Image, tagSeparator)[0]
-		if grpcImageRepo == defaultGrpcImageRepo {
-			modelregistrylog.V(4).Info("reset image", "grpc repo", grpcImageRepo)
-			// remove image altogether as the MR repo matches operator repo,
-			// so that future operator version upgrades don't have to handle a hardcoded default
-			r.Spec.Grpc.Image = emptyValue
-
-			// also reset resource requirements
-			r.Spec.Grpc.Resources = nil
-		}
-	}
-
 	// check rest image against operator default rest image repo
 	if len(r.Spec.Rest.Image) != 0 {
 		defaultRestImage := config.GetStringConfigWithDefault(config.RestImage, config.DefaultRestImage)
@@ -164,15 +147,8 @@ func (r *ModelRegistry) CleanupRuntimeDefaults() {
 func (r *ModelRegistry) RuntimeDefaults() {
 	modelregistrylog.Info("runtime defaults", "name", r.Name)
 
-	if r.Spec.Grpc.Resources == nil {
-		r.Spec.Grpc.Resources = config.MlmdGRPCResourceRequirements.DeepCopy()
-	}
-	if len(r.Spec.Grpc.Image) == 0 {
-		r.Spec.Grpc.Image = config.GetStringConfigWithDefault(config.GrpcImage, config.DefaultGrpcImage)
-	}
-
 	if r.Spec.Rest.Resources == nil {
-		r.Spec.Rest.Resources = config.MlmdRestResourceRequirements.DeepCopy()
+		r.Spec.Rest.Resources = config.ModelRegistryRestResourceRequirements.DeepCopy()
 	}
 	if len(r.Spec.Rest.Image) == 0 {
 		r.Spec.Rest.Image = config.GetStringConfigWithDefault(config.RestImage, config.DefaultRestImage)

--- a/api/v1alpha1/modelregistry_webhook_test.go
+++ b/api/v1alpha1/modelregistry_webhook_test.go
@@ -175,12 +175,12 @@ func TestCleanupRuntimeDefaults(t *testing.T) {
 			mrSpec: &v1alpha1.ModelRegistry{
 				Spec: v1alpha1.ModelRegistrySpec{
 					Rest: v1alpha1.RestSpec{
-						Resources: config.MlmdRestResourceRequirements.DeepCopy(),
+						Resources: config.ModelRegistryRestResourceRequirements.DeepCopy(),
 						Image:     config.DefaultRestImage,
 					},
 					Grpc: v1alpha1.GrpcSpec{
-						Resources: config.MlmdGRPCResourceRequirements.DeepCopy(),
-						Image:     config.DefaultGrpcImage,
+						Resources: nil,
+						Image:     "",
 					},
 					Istio: &v1alpha1.IstioConfig{
 						Audiences:        []string{audience},
@@ -270,11 +270,11 @@ func TestRuntimeDefaults(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "default"},
 				Spec: v1alpha1.ModelRegistrySpec{
 					Grpc: v1alpha1.GrpcSpec{
-						Resources: config.MlmdGRPCResourceRequirements.DeepCopy(),
-						Image:     config.DefaultGrpcImage,
+						Resources: nil,
+						Image:     "",
 					},
 					Rest: v1alpha1.RestSpec{
-						Resources: config.MlmdRestResourceRequirements.DeepCopy(),
+						Resources: config.ModelRegistryRestResourceRequirements.DeepCopy(),
 						Image:     config.DefaultRestImage,
 					},
 					// istio config is replaced with default oauth proxy config
@@ -308,11 +308,11 @@ func TestRuntimeDefaults(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "default"},
 				Spec: v1alpha1.ModelRegistrySpec{
 					Grpc: v1alpha1.GrpcSpec{
-						Resources: config.MlmdGRPCResourceRequirements.DeepCopy(),
-						Image:     config.DefaultGrpcImage,
+						Resources: nil,
+						Image:     "",
 					},
 					Rest: v1alpha1.RestSpec{
-						Resources: config.MlmdRestResourceRequirements.DeepCopy(),
+						Resources: config.ModelRegistryRestResourceRequirements.DeepCopy(),
 						Image:     config.DefaultRestImage,
 					},
 					OAuthProxy: &v1alpha1.OAuthProxyConfig{

--- a/api/v1beta1/modelregistry_types.go
+++ b/api/v1beta1/modelregistry_types.go
@@ -69,7 +69,7 @@ type PostgresConfig struct {
 	Database string `json:"database,omitempty"`
 
 	//+kubebuilder:default=false
-	// True if skipping database instance creation during ML Metadata
+	// True if skipping database instance creation during Model Registry
 	// service initialization. By default, it is false.
 	SkipDBCreation bool `json:"skipDBCreation,omitempty"`
 
@@ -135,7 +135,7 @@ type MySQLConfig struct {
 	Database string `json:"database"`
 
 	//+kubebuilder:default=false
-	// True if skipping database instance creation during ML Metadata
+	// True if skipping database instance creation during Model Registry
 	// service initialization. By default, it is false.
 	SkipDBCreation bool `json:"skipDBCreation,omitempty"`
 
@@ -185,6 +185,7 @@ type RestSpec struct {
 	Image string `json:"image,omitempty"`
 }
 
+// Deprecated: This type will be removed in a future API version.
 type GrpcSpec struct {
 	//+kubebuilder:default=9090
 	//+kubebuilder:validation:Minimum=0
@@ -313,7 +314,7 @@ type ModelRegistrySpec struct {
 
 	//+kubebuilder:required
 
-	// Configuration for gRPC endpoint
+	// Deprecated: Configuration for gRPC endpoint is deprecated and will be removed in a future release
 	Grpc GrpcSpec `json:"grpc"`
 
 	// PostgreSQL configuration options

--- a/api/v1beta1/modelregistry_webhook.go
+++ b/api/v1beta1/modelregistry_webhook.go
@@ -92,23 +92,6 @@ func (r *ModelRegistry) CleanupRuntimeDefaults() {
 		return
 	}
 
-	// check grpc image against operator default grpc image repo
-	if len(r.Spec.Grpc.Image) != 0 {
-		defaultGrpcImage := config.GetStringConfigWithDefault(config.GrpcImage, config.DefaultGrpcImage)
-		defaultGrpcImageRepo := strings.Split(defaultGrpcImage, tagSeparator)[0]
-
-		grpcImageRepo := strings.Split(r.Spec.Grpc.Image, tagSeparator)[0]
-		if grpcImageRepo == defaultGrpcImageRepo {
-			modelregistrylog.V(4).Info("reset image", "grpc repo", grpcImageRepo)
-			// remove image altogether as the MR repo matches operator repo,
-			// so that future operator version upgrades don't have to handle a hardcoded default
-			r.Spec.Grpc.Image = emptyValue
-
-			// also reset resource requirements
-			r.Spec.Grpc.Resources = nil
-		}
-	}
-
 	// check rest image against operator default rest image repo
 	if len(r.Spec.Rest.Image) != 0 {
 		defaultRestImage := config.GetStringConfigWithDefault(config.RestImage, config.DefaultRestImage)
@@ -131,15 +114,13 @@ func (r *ModelRegistry) CleanupRuntimeDefaults() {
 func (r *ModelRegistry) RuntimeDefaults() {
 	modelregistrylog.Info("runtime defaults", "name", r.Name)
 
-	if r.Spec.Grpc.Resources == nil {
-		r.Spec.Grpc.Resources = config.MlmdGRPCResourceRequirements.DeepCopy()
-	}
-	if len(r.Spec.Grpc.Image) == 0 {
-		r.Spec.Grpc.Image = config.GetStringConfigWithDefault(config.GrpcImage, config.DefaultGrpcImage)
+	// Add deprecation warning for gRPC usage
+	if r.Spec.Grpc.Port != nil || len(r.Spec.Grpc.Image) > 0 || r.Spec.Grpc.Resources != nil {
+		modelregistrylog.Info("DEPRECATION WARNING: gRPC configuration is deprecated and will be removed in a future release. Please migrate to REST-only configuration.", "name", r.Name)
 	}
 
 	if r.Spec.Rest.Resources == nil {
-		r.Spec.Rest.Resources = config.MlmdRestResourceRequirements.DeepCopy()
+		r.Spec.Rest.Resources = config.ModelRegistryRestResourceRequirements.DeepCopy()
 	}
 	if len(r.Spec.Rest.Image) == 0 {
 		r.Spec.Rest.Image = config.GetStringConfigWithDefault(config.RestImage, config.DefaultRestImage)

--- a/api/v1beta1/modelregistry_webhook_test.go
+++ b/api/v1beta1/modelregistry_webhook_test.go
@@ -235,22 +235,14 @@ func TestCleanupRuntimeDefaults(t *testing.T) {
 			mrSpec: &v1beta1.ModelRegistry{
 				Spec: v1beta1.ModelRegistrySpec{
 					Rest: v1beta1.RestSpec{
-						Resources: config.MlmdRestResourceRequirements.DeepCopy(),
+						Resources: config.ModelRegistryRestResourceRequirements.DeepCopy(),
 						Image:     config.DefaultRestImage,
-					},
-					Grpc: v1beta1.GrpcSpec{
-						Resources: config.MlmdGRPCResourceRequirements.DeepCopy(),
-						Image:     config.DefaultGrpcImage,
 					},
 				},
 			},
 			wantMrSpec: &v1beta1.ModelRegistry{
 				Spec: v1beta1.ModelRegistrySpec{
 					Rest: v1beta1.RestSpec{
-						Resources: nil,
-						Image:     "",
-					},
-					Grpc: v1beta1.GrpcSpec{
 						Resources: nil,
 						Image:     "",
 					},
@@ -288,12 +280,8 @@ func TestRuntimeDefaults(t *testing.T) {
 			wantMrSpec: &v1beta1.ModelRegistry{
 				ObjectMeta: metav1.ObjectMeta{Name: "default"},
 				Spec: v1beta1.ModelRegistrySpec{
-					Grpc: v1beta1.GrpcSpec{
-						Resources: config.MlmdGRPCResourceRequirements.DeepCopy(),
-						Image:     config.DefaultGrpcImage,
-					},
 					Rest: v1beta1.RestSpec{
-						Resources: config.MlmdRestResourceRequirements.DeepCopy(),
+						Resources: config.ModelRegistryRestResourceRequirements.DeepCopy(),
 						Image:     config.DefaultRestImage,
 					},
 					// No runtime defaults for oauth proxy config

--- a/config/component_metadata.yaml
+++ b/config/component_metadata.yaml
@@ -1,7 +1,4 @@
 releases:
-  - name: Google ML Metadata
-    version: v1.14.0
-    repoUrl: https://github.com/google/ml-metadata
   - name: Kubeflow Model Registry
     version: latest
     repoUrl: https://github.com/kubeflow/model-registry

--- a/config/crd/bases/modelregistry.opendatahub.io_modelregistries.yaml
+++ b/config/crd/bases/modelregistry.opendatahub.io_modelregistries.yaml
@@ -901,7 +901,8 @@ spec:
                   database migration during initialization (Optional parameter)
                 type: boolean
               grpc:
-                description: Configuration for gRPC endpoint
+                description: 'Deprecated: Configuration for gRPC endpoint is deprecated
+                  and will be removed in a future release'
                 properties:
                   image:
                     description: Optional image to support overriding the image deployed
@@ -1088,7 +1089,7 @@ spec:
                   skipDBCreation:
                     default: false
                     description: |-
-                      True if skipping database instance creation during ML Metadata
+                      True if skipping database instance creation during Model Registry
                       service initialization. By default, it is false.
                     type: boolean
                   sslCertificateSecret:
@@ -1299,7 +1300,7 @@ spec:
                   skipDBCreation:
                     default: false
                     description: |-
-                      True if skipping database instance creation during ML Metadata
+                      True if skipping database instance creation during Model Registry
                       service initialization. By default, it is false.
                     type: boolean
                   sslCertificateSecret:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -73,8 +73,6 @@ spec:
         image: controller
         name: manager
         env:
-          - name: GRPC_IMAGE
-            value: quay.io/opendatahub/mlmd-grpc-server:latest
           - name: REST_IMAGE
             value: quay.io/opendatahub/model-registry:latest
           - name: OAUTH_PROXY_IMAGE

--- a/config/overlays/odh/params.env
+++ b/config/overlays/odh/params.env
@@ -1,5 +1,4 @@
 IMAGES_MODELREGISTRY_OPERATOR=quay.io/opendatahub/model-registry-operator:latest
-IMAGES_GRPC_SERVICE=quay.io/opendatahub/mlmd-grpc-server:latest
 IMAGES_REST_SERVICE=quay.io/opendatahub/model-registry:latest
 IMAGES_OAUTH_PROXY=quay.io/openshift/origin-oauth-proxy:latest
 kube-rbac-proxy=quay.io/openshift/origin-kube-rbac-proxy:latest

--- a/config/overlays/odh/replacements.yaml
+++ b/config/overlays/odh/replacements.yaml
@@ -12,16 +12,6 @@
 - source:
     kind: ConfigMap
     name: model-registry-operator-parameters
-    fieldPath: data.IMAGES_GRPC_SERVICE
-  targets:
-    - select:
-        kind: Deployment
-        name: controller-manager
-      fieldPaths:
-        - spec.template.spec.containers.[name=manager].env.[name=GRPC_IMAGE].value
-- source:
-    kind: ConfigMap
-    name: model-registry-operator-parameters
     fieldPath: data.IMAGES_REST_SERVICE
   targets:
     - select:

--- a/config/samples/mariadb/mariadb-db.yaml
+++ b/config/samples/mariadb/mariadb-db.yaml
@@ -185,6 +185,6 @@ items:
   stringData:
     database-name: "model_registry"
     database-password: "TheBlurstOfTimes" # notsecret
-    database-user: "mlmduser" # notsecret
+    database-user: "modelregistryuser" # notsecret
 kind: List
 metadata: {}

--- a/config/samples/mariadb/modelregistry_v1beta1_modelregistry.yaml
+++ b/config/samples/mariadb/modelregistry_v1beta1_modelregistry.yaml
@@ -18,7 +18,7 @@ spec:
   mysql:
     host: model-registry-db
     database: model_registry
-    username: mlmduser
+    username: modelregistryuser
     passwordSecret:
       name: model-registry-db
       key: database-password

--- a/config/samples/mysql/modelregistry_v1beta1_modelregistry.yaml
+++ b/config/samples/mysql/modelregistry_v1beta1_modelregistry.yaml
@@ -18,7 +18,7 @@ spec:
   mysql:
     host: model-registry-db
     database: model_registry
-    username: mlmduser
+    username: modelregistryuser
     passwordSecret:
       name: model-registry-db
       key: database-password

--- a/config/samples/mysql/mysql-db.yaml
+++ b/config/samples/mysql/mysql-db.yaml
@@ -141,6 +141,6 @@ items:
   stringData:
     database-name: "model_registry"
     database-password: "TheBlurstOfTimes" # notsecret
-    database-user: "mlmduser" # notsecret
+    database-user: "modelregistryuser" # notsecret
 kind: List
 metadata: {}

--- a/config/samples/postgres/modelregistry_v1beta1_modelregistry.yaml
+++ b/config/samples/postgres/modelregistry_v1beta1_modelregistry.yaml
@@ -18,7 +18,7 @@ spec:
   postgres:
     host: model-registry-db
     database: model-registry
-    username: mlmduser
+    username: modelregistryuser
     passwordSecret:
       name: model-registry-db
       key: database-password

--- a/config/samples/postgres/postgres-db.yaml
+++ b/config/samples/postgres/postgres-db.yaml
@@ -133,6 +133,6 @@ items:
   stringData:
     database-name: "model-registry"
     database-password: "TheBlurstOfTimes" # notsecret
-    database-user: "mlmduser" # notsecret
+    database-user: "modelregistryuser" # notsecret
 kind: List
 metadata: {}

--- a/docs/install.md
+++ b/docs/install.md
@@ -387,7 +387,7 @@ items:
   stringData:
     database-name: "model_registry"
     database-password: "TheBlurstOfTimes" # notsecret
-    database-user: "mlmduser" # notsecret
+    database-user: "modelregistryuser" # notsecret
 kind: List
 metadata: {}
 EOF
@@ -401,6 +401,9 @@ oc wait --for=condition=available deployment/model-registry-db --timeout=5m
 If you encounter image pull limits, you could replace the sample db image with analogous one from (upstream [example](https://github.com/kubeflow/model-registry?tab=readme-ov-file#pull-image-rate-limiting)).
 
 ## Install Model Registry
+
+> [!NOTE]
+> **gRPC Endpoint Deprecation**: The gRPC endpoint configuration is deprecated and will be removed in a future release. New deployments should use the REST endpoint configuration only. Existing deployments with gRPC will continue to work but should migrate to REST-only configurations.
 
 To install Model Registry use the following script. Create a namespace where you going to be installing the model registry
 
@@ -429,7 +432,7 @@ items:
     stringData:
       database-name: model_registry
       database-password: TheBlurstOfTimes
-      database-user: mlmduser
+      database-user: modelregistryuser
   - apiVersion: modelregistry.opendatahub.io/v1alpha1
     kind: ModelRegistry
     metadata:
@@ -442,13 +445,10 @@ items:
       name: modelregistry-public
       namespace: odh-model-registries
     spec:
-      grpc: {}
       rest: {}
       istio:
         authProvider: opendatahub-auth-provider
         gateway:
-          grpc:
-            tls: {}
           rest:
             tls: {}
       mysql:
@@ -459,7 +459,7 @@ items:
           name: model-registry-db
         port: 3306
         skipDBCreation: false
-        username: mlmduser
+        username: modelregistryuser
 kind: List
 metadata: {}
 EOF

--- a/internal/controller/config/defaults.go
+++ b/internal/controller/config/defaults.go
@@ -42,14 +42,12 @@ import (
 var templateFS embed.FS
 
 const (
-	GrpcImage                 = "GRPC_IMAGE"
 	RestImage                 = "REST_IMAGE"
 	OAuthProxyImage           = "OAUTH_PROXY_IMAGE"
 	KubeRBACProxyImage        = "KUBE_RBAC_PROXY_IMAGE"
 	PostgresImage             = "POSTGRES_IMAGE"
 	CatalogDataImage          = "CATALOG_DATA_IMAGE"
 	BenchmarkDataImage        = "BENCHMARK_DATA_IMAGE"
-	DefaultGrpcImage          = "quay.io/opendatahub/mlmd-grpc-server:latest"
 	DefaultRestImage          = "quay.io/opendatahub/model-registry:latest"
 	DefaultOAuthProxyImage    = "quay.io/openshift/origin-oauth-proxy:latest"
 	DefaultKubeRBACProxyImage = "quay.io/openshift/origin-kube-rbac-proxy:latest"
@@ -83,9 +81,8 @@ var (
 	defaultRegistriesNamespace = ""
 
 	// Default ResourceRequirements
-	CatalogServiceResourceRequirements = createResourceRequirement(resource.MustParse("100m"), resource.MustParse("256Mi"), resource.MustParse("0m"), resource.MustParse("256Mi"))
-	MlmdRestResourceRequirements       = createResourceRequirement(resource.MustParse("100m"), resource.MustParse("256Mi"), resource.MustParse("0m"), resource.MustParse("256Mi"))
-	MlmdGRPCResourceRequirements       = createResourceRequirement(resource.MustParse("100m"), resource.MustParse("256Mi"), resource.MustParse("0m"), resource.MustParse("256Mi"))
+	CatalogServiceResourceRequirements    = createResourceRequirement(resource.MustParse("100m"), resource.MustParse("256Mi"), resource.MustParse("0m"), resource.MustParse("256Mi"))
+	ModelRegistryRestResourceRequirements = createResourceRequirement(resource.MustParse("100m"), resource.MustParse("256Mi"), resource.MustParse("0m"), resource.MustParse("256Mi"))
 )
 
 func init() {

--- a/internal/controller/config/defaults_test.go
+++ b/internal/controller/config/defaults_test.go
@@ -26,19 +26,18 @@ func TestGetStringConfigWithDefault(t *testing.T) {
 		defaultValue string
 		want         string
 	}{
-		{name: "test " + config.GrpcImage, configName: config.GrpcImage, defaultValue: config.DefaultGrpcImage, want: "success1"},
-		{name: "test " + config.RestImage, configName: config.RestImage, defaultValue: config.DefaultRestImage, want: "success2"},
-		{name: "test " + config.OAuthProxyImage, configName: config.OAuthProxyImage, defaultValue: config.DefaultOAuthProxyImage, want: "success3"},
+		{name: "test " + config.RestImage, configName: config.RestImage, defaultValue: config.DefaultRestImage, want: "success1"},
+		{name: "test " + config.OAuthProxyImage, configName: config.OAuthProxyImage, defaultValue: config.DefaultOAuthProxyImage, want: "success2"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// test env variable not set or blank
-			os.Setenv(tt.configName, "")
+			t.Setenv(tt.configName, "")
 			if got := config.GetStringConfigWithDefault(tt.configName, tt.defaultValue); got != tt.defaultValue {
 				t.Errorf("GetStringConfigWithDefault() = %v, want %v", got, tt.want)
 			}
 			// test env variable set
-			os.Setenv(tt.configName, tt.want)
+			t.Setenv(tt.configName, tt.want)
 			if got := config.GetStringConfigWithDefault(tt.configName, "fail"); got != tt.want {
 				t.Errorf("GetStringConfigWithDefault() = %v, want %v", got, tt.want)
 			}
@@ -324,12 +323,12 @@ func TestDeploymentWithResources(t *testing.T) {
 				Image: "quay.io/opendatahub/model-registry:latest",
 				Resources: &corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
-						"cpu":    config.MlmdRestResourceRequirements.Requests["cpu"],
-						"memory": config.MlmdRestResourceRequirements.Requests["memory"],
+						"cpu":    config.ModelRegistryRestResourceRequirements.Requests["cpu"],
+						"memory": config.ModelRegistryRestResourceRequirements.Requests["memory"],
 					},
 					Limits: corev1.ResourceList{
-						"cpu":    config.MlmdRestResourceRequirements.Limits["cpu"],
-						"memory": config.MlmdRestResourceRequirements.Limits["memory"],
+						"cpu":    config.ModelRegistryRestResourceRequirements.Limits["cpu"],
+						"memory": config.ModelRegistryRestResourceRequirements.Limits["memory"],
 					},
 				},
 			},

--- a/internal/controller/modelregistry_controller_test.go
+++ b/internal/controller/modelregistry_controller_test.go
@@ -68,8 +68,6 @@ var _ = Describe("ModelRegistry controller", func() {
 
 			BeforeEach(func() {
 				By("Setting the Image ENV VARs which stores the Server images")
-				err = os.Setenv(config.GrpcImage, config.DefaultGrpcImage)
-				Expect(err).To(Not(HaveOccurred()))
 				err = os.Setenv(config.RestImage, config.DefaultRestImage)
 				Expect(err).To(Not(HaveOccurred()))
 				err = os.Setenv(config.PostgresImage, config.DefaultPostgresImage)
@@ -98,7 +96,6 @@ var _ = Describe("ModelRegistry controller", func() {
 
 				// Let's mock our custom resource in the same way that we would
 				// apply on the cluster the manifest under config/samples
-				var gRPCPort int32 = 9090
 				var restPort int32 = 8080
 				modelRegistry = &v1beta1.ModelRegistry{
 					ObjectMeta: metav1.ObjectMeta{
@@ -107,9 +104,6 @@ var _ = Describe("ModelRegistry controller", func() {
 						Annotations: map[string]string{DisplayNameAnnotation: registryName, DescriptionAnnotation: DescriptionPrefix + registryName},
 					},
 					Spec: v1beta1.ModelRegistrySpec{
-						Grpc: v1beta1.GrpcSpec{
-							Port: &gRPCPort,
-						},
 						Rest: v1beta1.RestSpec{
 							Port: &restPort,
 						},
@@ -127,7 +121,7 @@ var _ = Describe("ModelRegistry controller", func() {
 					Host:     "model-registry-db",
 					Port:     &postgresPort,
 					Database: "model-registry",
-					Username: "mlmduser",
+					Username: "modelregistryuser",
 					PasswordSecret: &v1beta1.SecretKeyValue{
 						Name: "model-registry-db",
 						Key:  "database-password",
@@ -156,7 +150,7 @@ var _ = Describe("ModelRegistry controller", func() {
 					Host:     "model-registry-db",
 					Port:     &postgresPort,
 					Database: "model-registry",
-					Username: "mlmduser",
+					Username: "modelregistryuser",
 					PasswordSecret: &v1beta1.SecretKeyValue{
 						Name: "model-registry-db",
 						Key:  "database-password",
@@ -245,7 +239,7 @@ var _ = Describe("ModelRegistry controller", func() {
 					Host:     "model-registry-db",
 					Port:     &postgresPort,
 					Database: "model-registry",
-					Username: "mlmduser",
+					Username: "modelregistryuser",
 					PasswordSecret: &v1beta1.SecretKeyValue{
 						Name: "model-registry-db",
 						Key:  "database-password",
@@ -327,7 +321,7 @@ var _ = Describe("ModelRegistry controller", func() {
 					Host:     "model-registry-db",
 					Port:     &mySQLPort,
 					Database: "model_registry",
-					Username: "mlmduser",
+					Username: "modelregistryuser",
 					PasswordSecret: &v1beta1.SecretKeyValue{
 						Name: "model-registry-db",
 						Key:  "database-password",
@@ -353,7 +347,7 @@ var _ = Describe("ModelRegistry controller", func() {
 					Host:     "model-registry-db",
 					Port:     &mySQLPort,
 					Database: "model_registry",
-					Username: "mlmduser",
+					Username: "modelregistryuser",
 					PasswordSecret: &v1beta1.SecretKeyValue{
 						Name: "model-registry-db",
 						Key:  "database-password",
@@ -387,7 +381,7 @@ var _ = Describe("ModelRegistry controller", func() {
 					Host:     "model-registry-db",
 					Port:     &mySQLPort,
 					Database: "model_registry",
-					Username: "mlmduser",
+					Username: "modelregistryuser",
 					PasswordSecret: &v1beta1.SecretKeyValue{
 						Name: "model-registry-db",
 						Key:  "database-password",
@@ -419,7 +413,7 @@ var _ = Describe("ModelRegistry controller", func() {
 					Host:     "model-registry-db",
 					Port:     &mySQLPort,
 					Database: "model_registry",
-					Username: "mlmduser",
+					Username: "modelregistryuser",
 					PasswordSecret: &v1beta1.SecretKeyValue{
 						Name: "model-registry-db",
 						Key:  "database-password",
@@ -533,7 +527,7 @@ var _ = Describe("ModelRegistry controller", func() {
 						Host:     "model-registry-db",
 						Port:     &mySQLPort,
 						Database: "model_registry",
-						Username: "mlmduser",
+						Username: "modelregistryuser",
 						PasswordSecret: &v1beta1.SecretKeyValue{
 							Name: "model-registry-db",
 							Key:  "database-password",
@@ -710,7 +704,6 @@ var _ = Describe("ModelRegistry controller", func() {
 				_ = k8sClient.Delete(ctx, namespace)
 
 				By("Removing the Image ENV VARs which stores the Server images")
-				_ = os.Unsetenv(config.GrpcImage)
 				_ = os.Unsetenv(config.RestImage)
 				_ = os.Unsetenv(config.OAuthProxyImage)
 			})

--- a/internal/migration/migration_test.go
+++ b/internal/migration/migration_test.go
@@ -119,7 +119,6 @@ var _ = Describe("Storage Version Migration", func() {
 			testMR.SetNamespace(testNamespace)
 			testMR.Spec = v1alpha1.ModelRegistrySpec{
 				Rest: v1alpha1.RestSpec{},
-				Grpc: v1alpha1.GrpcSpec{},
 			}
 			Expect(k8sClient.Create(ctx, testMR)).To(Succeed())
 		})
@@ -209,7 +208,6 @@ var _ = Describe("Storage Version Migration", func() {
 			testMR.SetNamespace(testNamespace)
 			testMR.Spec = v1alpha1.ModelRegistrySpec{
 				Rest: v1alpha1.RestSpec{},
-				Grpc: v1alpha1.GrpcSpec{},
 			}
 			Expect(k8sClient.Create(ctx, testMR)).To(Succeed())
 		})
@@ -285,9 +283,6 @@ var _ = Describe("Storage Version Migration", func() {
 				Rest: v1alpha1.RestSpec{
 					Image: "test-rest-image",
 				},
-				Grpc: v1alpha1.GrpcSpec{
-					Image: "test-grpc-image",
-				},
 				MySQL: &v1alpha1.MySQLConfig{
 					Host:     "test-mysql",
 					Port:     &dbPort,
@@ -324,7 +319,6 @@ var _ = Describe("Storage Version Migration", func() {
 
 			// Verify key fields are preserved
 			Expect(convertedMR.Spec.Rest.Image).To(Equal(originalMR.Spec.Rest.Image))
-			Expect(convertedMR.Spec.Grpc.Image).To(Equal(originalMR.Spec.Grpc.Image))
 
 			if originalMR.Spec.MySQL != nil && convertedMR.Spec.MySQL != nil {
 				Expect(convertedMR.Spec.MySQL.Host).To(Equal(originalMR.Spec.MySQL.Host))


### PR DESCRIPTION
Removes remaining traces of Google ML Metadata (MLMD) and deprecates
related APIs.

Specifically, these changes:

  - Deprecate grpc configuration in v1beta1 API with proper deprecation markers
  - Maintain backward compatibility through optional grpc fields in both API versions
  - Remove grpc implementation while preserving API compatibility
  - Update database comments from "ML Metadata" to "Model Registry"
  - Remove ODH replacement configuration for GRPC_SERVICE
  - Clean up grpc error handling references in status controller

fixes RHOAIENG-33462

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Deprecations**
  * gRPC endpoint configuration is deprecated; REST-only configuration is recommended for new deployments and will show deprecation warnings.

* **Changes**
  * Database usernames updated from `mlmduser` to `modelregistryuser` across sample manifests and secrets.
  * gRPC-related image/config wiring and sync steps removed from deployment flows; runtime defaults now focus on REST resources.

* **Documentation**
  * Install docs and README updated to reflect gRPC deprecation and REST-focused installation guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->