### PR TITLE
feat(catalog): split the sources configmap

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -12,6 +12,8 @@ rules:
   - create
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - ""

--- a/go.mod
+++ b/go.mod
@@ -14,9 +14,11 @@ require (
 	github.com/spf13/viper v1.18.2
 	istio.io/client-go v1.20.3-0.20240116015948-bc198a253520
 	k8s.io/api v0.28.3
+	k8s.io/apiextensions-apiserver v0.28.3
 	k8s.io/apimachinery v0.28.3
 	k8s.io/client-go v0.28.3
 	sigs.k8s.io/controller-runtime v0.16.3
+	sigs.k8s.io/yaml v1.3.0
 )
 
 require (
@@ -117,7 +119,6 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	istio.io/api v1.20.3-0.20240116015448-5563f7225778 // indirect
-	k8s.io/apiextensions-apiserver v0.28.3 // indirect
 	k8s.io/apiserver v0.28.3 // indirect
 	k8s.io/component-base v0.28.3 // indirect
 	k8s.io/klog/v2 v2.100.1 // indirect
@@ -127,5 +128,4 @@ require (
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.1.2 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.3.0 // indirect
-	sigs.k8s.io/yaml v1.3.0 // indirect
 )

--- a/internal/controller/config/templates/catalog/catalog-default-configmap.yaml.tmpl
+++ b/internal/controller/config/templates/catalog/catalog-default-configmap.yaml.tmpl
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: "model-catalog-sources"
+  name: "model-catalog-default-sources"
   namespace: {{.Namespace}}
   labels:
     app: {{.Name}}
@@ -14,4 +14,9 @@ metadata:
     app.kubernetes.io/managed-by: model-registry-operator
 data:
   sources.yaml: |-
-    catalogs: []
+    catalogs:
+      - name: Default Catalog
+        id: default_catalog
+        type: yaml
+        properties:
+          yamlCatalogPath: /shared-data/default-catalog.yaml

--- a/internal/controller/config/templates/catalog/catalog-deployment.yaml.tmpl
+++ b/internal/controller/config/templates/catalog/catalog-deployment.yaml.tmpl
@@ -32,9 +32,12 @@ spec:
           type: RuntimeDefault
         runAsNonRoot: true
       volumes:
-      - name: sources
+      - name: user-sources
         configMap:
           name: model-catalog-sources
+      - name: default-sources
+        configMap:
+          name: model-catalog-default-sources
       - name: catalog-data
         emptyDir: {}
       - name: benchmark-data
@@ -86,7 +89,8 @@ spec:
             - catalog
           args:
             - --listen=0.0.0.0:8080
-            - --catalogs-path=/catalog/sources.yaml
+            - --catalogs-path=/data/user-sources/sources.yaml
+            - --catalogs-path=/data/default-sources/sources.yaml
           image: {{.Spec.Rest.Image}}
           ports:
             - name: http-api
@@ -122,8 +126,10 @@ spec:
               drop:
                 - ALL
           volumeMounts:
-          - name: sources
-            mountPath: /catalog
+          - name: user-sources
+            mountPath: /data/user-sources
+          - name: default-sources
+            mountPath: /data/default-sources
           - name: catalog-data
             mountPath: /shared-data
           - name: benchmark-data

--- a/internal/controller/kubebuilder.go
+++ b/internal/controller/kubebuilder.go
@@ -1,0 +1,24 @@
+// NOTE: There MUST be an empty newline at the end of this rbac permissions list, or role generation won't work!!!
+// +kubebuilder:rbac:groups=modelregistry.opendatahub.io,resources=modelregistries,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=modelregistry.opendatahub.io,resources=modelregistries/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=modelregistry.opendatahub.io,resources=modelregistries/finalizers,verbs=update
+// +kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=pods;pods/log,verbs=get;list;watch
+// +kubebuilder:rbac:groups=core,resources=services;serviceaccounts,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=endpoints,verbs=get;list;watch
+// +kubebuilder:rbac:groups=core,resources=configmaps,verbs=create;get;list;watch;patch;update
+// +kubebuilder:rbac:groups=core,resources=secrets,verbs=create;get;list;watch;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=persistentvolumeclaims,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=config.openshift.io,resources=ingresses,verbs=get;list;watch
+// +kubebuilder:rbac:groups=route.openshift.io,resources=routes;routes/custom-host,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=user.openshift.io,resources=groups,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings;clusterrolebindings,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=authentication.k8s.io,resources=tokenreviews,verbs=create
+// +kubebuilder:rbac:groups=authorization.k8s.io,resources=subjectaccessreviews,verbs=create
+// +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=migration.k8s.io,resources=storageversionmigrations,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch
+// +kubebuilder:rbac:groups=components.platform.opendatahub.io,resources=modelregistries,verbs=get;list;watch
+
+package controller

--- a/internal/controller/modelregistry_controller.go
+++ b/internal/controller/modelregistry_controller.go
@@ -309,29 +309,6 @@ func (r *ModelRegistryReconciler) GetRegistryForClusterRoleBinding(ctx context.C
 	}
 }
 
-// NOTE: There MUST be an empty newline at the end of this rbac permissions list, or role generation won't work!!!
-// +kubebuilder:rbac:groups=modelregistry.opendatahub.io,resources=modelregistries,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=modelregistry.opendatahub.io,resources=modelregistries/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=modelregistry.opendatahub.io,resources=modelregistries/finalizers,verbs=update
-// +kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
-// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=core,resources=pods;pods/log,verbs=get;list;watch
-// +kubebuilder:rbac:groups=core,resources=services;serviceaccounts,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=core,resources=endpoints,verbs=get;list;watch
-// +kubebuilder:rbac:groups=core,resources=configmaps,verbs=create;get;list;watch
-// +kubebuilder:rbac:groups=core,resources=secrets,verbs=create;get;list;watch;update;patch;delete
-// +kubebuilder:rbac:groups=core,resources=persistentvolumeclaims,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=config.openshift.io,resources=ingresses,verbs=get;list;watch
-// +kubebuilder:rbac:groups=route.openshift.io,resources=routes;routes/custom-host,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=user.openshift.io,resources=groups,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings;clusterrolebindings,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=authentication.k8s.io,resources=tokenreviews,verbs=create
-// +kubebuilder:rbac:groups=authorization.k8s.io,resources=subjectaccessreviews,verbs=create
-// +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=migration.k8s.io,resources=storageversionmigrations,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch
-// +kubebuilder:rbac:groups=components.platform.opendatahub.io,resources=modelregistries,verbs=get;list;watch
-
 func (r *ModelRegistryReconciler) updateRegistryResources(ctx context.Context, params *ModelRegistryParams, registry *v1beta1.ModelRegistry) (OperationResult, error) {
 
 	//log := klog.FromContext(ctx)


### PR DESCRIPTION
## Description

Add a second sources configmap for the default catalog, which is
completely managed by the controller.

The existing sources configmap will continue to be user-editable,
however because the default catalog was included previously (and cannot
be added twice) the controller will examine the old sources configmap
and remove the default catalog if found.

## How Has This Been Tested?
Unit tests and tested on a dev cluster.

## Merge criteria:

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Separates default and user-managed model catalogs; operator now provisions a default catalog and mounts both default and user sources.

- Improvements
  - Automatic migration removes bundled default entries from user configs to avoid conflicts.
  - More reliable reconciliation that restores defaults and handles malformed catalog files gracefully.
  - Adds owner references for cleaner resource lifecycle management.

- Permissions
  - ConfigMap update/patch permissions expanded.

- Chores
  - Promoted previously indirect dependencies to direct module requirements.

- Tests
  - Expanded test coverage for catalog migration and ConfigMap scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->