### PR TITLE
feat(catalog): discover labeled ConfigMaps as additional catalog sources

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -153,7 +153,6 @@ func main() {
 	cacheOptions := cache.Options{
 		ByObject: map[client.Object]cache.ByObject{
 			&appsv1.Deployment{}:            objOptions,
-			&corev1.ConfigMap{}:             objOptions,
 			&corev1.PersistentVolumeClaim{}: objOptions,
 			&corev1.ServiceAccount{}:        objOptions,
 			&corev1.Service{}:               objOptions,
@@ -161,6 +160,14 @@ func main() {
 			&rbacv1.ClusterRoleBinding{}:    objOptions,
 			&rbacv1.RoleBinding{}:           objOptions,
 			&rbacv1.Role{}:                  objOptions,
+			// ConfigMaps: cache all in the target namespace (no label filter)
+			// because user-created catalog source ConfigMaps won't have operator labels.
+			// Namespace-scoping keeps the cache bounded.
+			&corev1.ConfigMap{}: {
+				Namespaces: map[string]cache.Config{
+					registriesNamespace: {},
+				},
+			},
 		},
 	}
 

--- a/internal/controller/config/templates/catalog/catalog-deployment.yaml.tmpl
+++ b/internal/controller/config/templates/catalog/catalog-deployment.yaml.tmpl
@@ -46,6 +46,11 @@ spec:
         emptyDir: {}
       - name: benchmark-data
         emptyDir: {}
+      {{- range .LabeledSources}}
+      - name: labeled-{{.Name}}
+        configMap:
+          name: {{.Name}}
+      {{- end}}
       {{- if .Spec.KubeRBACProxy }}
       - name: kube-rbac-proxy-tls
         secret:
@@ -95,6 +100,9 @@ spec:
             - --catalogs-path=/data/default-sources/sources.yaml
             - --catalogs-path=/data/user-model-sources/sources.yaml
             - --catalogs-path=/data/user-mcp-sources/sources.yaml
+            {{- range .LabeledSources}}
+            - --catalogs-path=/data/labeled-sources/{{.Name}}/sources.yaml
+            {{- end}}
             - --performance-metrics=/shared-benchmark-data
           image: {{.Spec.Rest.Image}}
           ports:
@@ -143,6 +151,10 @@ spec:
             mountPath: /shared-data
           - name: benchmark-data
             mountPath: /shared-benchmark-data
+          {{- range .LabeledSources}}
+          - name: labeled-{{.Name}}
+            mountPath: /data/labeled-sources/{{.Name}}
+          {{- end}}
           env:
             - name: PGHOST
               value: {{.Name}}-postgres

--- a/internal/controller/modelcatalog_controller.go
+++ b/internal/controller/modelcatalog_controller.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"maps"
 	"reflect"
+	"regexp"
 	"slices"
 	"strings"
 	"text/template"
@@ -41,6 +42,10 @@ import (
 const modelCatalogName = "model-catalog"
 const modelCatalogPostgresName = "model-catalog-postgres"
 const catalogSourceLabel = "opendatahub.io/catalog-source"
+
+// dnsLabelRegex matches valid Kubernetes DNS label names (RFC 1123).
+// ConfigMap names are DNS subdomains (dots allowed) but volume names must be DNS labels (no dots).
+var dnsLabelRegex = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`)
 
 // LabeledSource represents a user-defined ConfigMap discovered via the catalogSourceLabel label.
 type LabeledSource struct {
@@ -125,8 +130,7 @@ func (r *ModelCatalogReconciler) ensureCatalogResources(ctx context.Context) (ct
 
 	labeledSources, err := r.discoverLabeledSources(ctx)
 	if err != nil {
-		log.Error(err, "Failed to discover labeled catalog sources, continuing without them")
-		labeledSources = []LabeledSource{}
+		return ctrl.Result{}, fmt.Errorf("failed to discover labeled catalog sources: %w", err)
 	}
 
 	catalogParams := &ModelCatalogParams{
@@ -1216,6 +1220,10 @@ func (r *ModelCatalogReconciler) discoverLabeledSources(ctx context.Context) ([]
 	for _, cm := range cmList.Items {
 		if len(cm.Name) > maxCMNameLen {
 			log.Info("Labeled catalog configmap name too long for volume name, skipping", "configmap", cm.Name, "maxLen", maxCMNameLen)
+			continue
+		}
+		if !dnsLabelRegex.MatchString(cm.Name) {
+			log.Info("Labeled catalog configmap name is not a valid DNS label, skipping", "configmap", cm.Name)
 			continue
 		}
 		if _, ok := cm.Data["sources.yaml"]; !ok {

--- a/internal/controller/modelcatalog_controller.go
+++ b/internal/controller/modelcatalog_controller.go
@@ -40,6 +40,12 @@ import (
 
 const modelCatalogName = "model-catalog"
 const modelCatalogPostgresName = "model-catalog-postgres"
+const catalogSourceLabel = "opendatahub.io/catalog-source"
+
+// LabeledSource represents a user-defined ConfigMap discovered via the catalogSourceLabel label.
+type LabeledSource struct {
+	Name string
+}
 
 // ModelCatalogReconciler reconciles a single model catalog instance
 type ModelCatalogReconciler struct {
@@ -66,11 +72,12 @@ type ModelCatalogReconciler struct {
 
 // ModelCatalogParams is a wrapper for template parameters
 type ModelCatalogParams struct {
-	Name          string
-	Namespace     string
-	Component     string
-	PostgresImage string
-	AdminGroups   []string
+	Name           string
+	Namespace      string
+	Component      string
+	PostgresImage  string
+	AdminGroups    []string
+	LabeledSources []LabeledSource
 }
 
 // createPostgresParams creates PostgreSQL-specific ModelCatalogParams.
@@ -116,11 +123,18 @@ func (r *ModelCatalogReconciler) ensureCatalogResources(ctx context.Context) (ct
 		}
 	}
 
+	labeledSources, err := r.discoverLabeledSources(ctx)
+	if err != nil {
+		log.Error(err, "Failed to discover labeled catalog sources, continuing without them")
+		labeledSources = []LabeledSource{}
+	}
+
 	catalogParams := &ModelCatalogParams{
-		Name:        modelCatalogName,
-		Namespace:   r.TargetNamespace,
-		Component:   modelCatalogName,
-		AdminGroups: adminGroups,
+		Name:           modelCatalogName,
+		Namespace:      r.TargetNamespace,
+		Component:      modelCatalogName,
+		AdminGroups:    adminGroups,
+		LabeledSources: labeledSources,
 	}
 
 	// Fetch the info from the platform's default-modelregistry CR to use an owner.
@@ -1093,6 +1107,7 @@ func (r *ModelCatalogReconciler) Apply(params *ModelCatalogParams, templateName 
 		PostgresUser       string
 		PostgresDatabase   string
 		AdminGroups        []string
+		LabeledSources     []LabeledSource
 	}{
 		Name:               params.Name,
 		Namespace:          params.Namespace,
@@ -1103,6 +1118,7 @@ func (r *ModelCatalogReconciler) Apply(params *ModelCatalogParams, templateName 
 		PostgresUser:       config.GetStringConfigWithDefault(config.CatalogPostgresUser, config.DefaultCatalogPostgresUser),
 		PostgresDatabase:   config.GetStringConfigWithDefault(config.CatalogPostgresDatabase, config.DefaultCatalogPostgresDatabase),
 		AdminGroups:        params.AdminGroups,
+		LabeledSources:     params.LabeledSources,
 	}
 
 	return r.templateApplier.Apply(catalogParams, templateName, object)
@@ -1179,6 +1195,41 @@ func (r *ModelCatalogReconciler) fetchDefaultModelRegistry(ctx context.Context) 
 	}, nil
 }
 
+// discoverLabeledSources lists ConfigMaps labeled with catalogSourceLabel in the target namespace.
+// Only ConfigMaps that contain a "sources.yaml" data key are included. Results are sorted
+// alphabetically by name so that precedence is deterministic.
+func (r *ModelCatalogReconciler) discoverLabeledSources(ctx context.Context) ([]LabeledSource, error) {
+	log := klog.FromContext(ctx)
+	var cmList corev1.ConfigMapList
+	if err := r.List(ctx, &cmList,
+		client.InNamespace(r.TargetNamespace),
+		client.MatchingLabels{catalogSourceLabel: "true"},
+	); err != nil {
+		return nil, fmt.Errorf("failed to list labeled catalog configmaps: %w", err)
+	}
+
+	// Kubernetes volume names are DNS labels: max 63 characters.
+	// Our volume names are "labeled-<configmap-name>", so the configmap name must be at most 55 chars.
+	const maxCMNameLen = 63 - len("labeled-")
+
+	sources := make([]LabeledSource, 0, len(cmList.Items))
+	for _, cm := range cmList.Items {
+		if len(cm.Name) > maxCMNameLen {
+			log.Info("Labeled catalog configmap name too long for volume name, skipping", "configmap", cm.Name, "maxLen", maxCMNameLen)
+			continue
+		}
+		if _, ok := cm.Data["sources.yaml"]; !ok {
+			log.Info("Labeled catalog configmap missing sources.yaml key, skipping", "configmap", cm.Name)
+			continue
+		}
+		sources = append(sources, LabeledSource{Name: cm.Name})
+	}
+	slices.SortFunc(sources, func(a, b LabeledSource) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+	return sources, nil
+}
+
 // fetchAuthConfig retrieves admin groups from the cluster-scoped Auth CR.
 // Returns a slice of admin group names, or an empty slice if the Auth CR is not found.
 func (r *ModelCatalogReconciler) fetchAuthConfig(ctx context.Context) ([]string, error) {
@@ -1243,12 +1294,18 @@ func (r *ModelCatalogReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 
 	// only watch resources in the target namespace
-	combinedPredicate := predicate.And(
-		labels,
-		predicate.NewPredicateFuncs(func(object client.Object) bool {
-			return object.GetNamespace() == r.TargetNamespace
-		}),
-	)
+	namespacePredicate := predicate.NewPredicateFuncs(func(object client.Object) bool {
+		return object.GetNamespace() == r.TargetNamespace
+	})
+	combinedPredicate := predicate.And(labels, namespacePredicate)
+
+	catalogSourceLabels, err := predicate.LabelSelectorPredicate(metav1.LabelSelector{
+		MatchLabels: map[string]string{catalogSourceLabel: "true"},
+	})
+	if err != nil {
+		return err
+	}
+	catalogSourcePredicate := predicate.And(catalogSourceLabels, namespacePredicate)
 
 	// Custom mapper that maps ALL watched objects to the same reconcile request
 	// This enables workqueue deduplication to prevent reconcile storms
@@ -1267,7 +1324,7 @@ func (r *ModelCatalogReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Named("modelcatalog").
 		// All watched resources now map to the same reconcile request for deduplication
 		Watches(&appsv1.Deployment{}, mapToFixedCatalogRequest, builder.WithPredicates(combinedPredicate)).
-		Watches(&corev1.ConfigMap{}, mapToFixedCatalogRequest, builder.WithPredicates(combinedPredicate)).
+		Watches(&corev1.ConfigMap{}, mapToFixedCatalogRequest, builder.WithPredicates(predicate.Or(combinedPredicate, catalogSourcePredicate))).
 		Watches(&corev1.Secret{}, mapToFixedCatalogRequest, builder.WithPredicates(combinedPredicate)).
 		Watches(&corev1.ServiceAccount{}, mapToFixedCatalogRequest, builder.WithPredicates(combinedPredicate)).
 		Watches(&corev1.Service{}, mapToFixedCatalogRequest, builder.WithPredicates(combinedPredicate)).

--- a/internal/controller/modelcatalog_controller_test.go
+++ b/internal/controller/modelcatalog_controller_test.go
@@ -1103,6 +1103,181 @@ catalogs:
 			})
 		})
 
+		Context("Label-based ConfigMap discovery", func() {
+			createLabeledConfigMap := func(name string, withSourcesKey bool) *corev1.ConfigMap {
+				cm := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      name,
+						Namespace: namespaceName,
+						Labels:    map[string]string{catalogSourceLabel: "true"},
+					},
+				}
+				if withSourcesKey {
+					cm.Data = map[string]string{
+						"sources.yaml": "catalogs: []\n",
+					}
+				}
+				return cm
+			}
+
+			It("Should include labeled ConfigMaps as additional volumes and args", func() {
+				By("Creating labeled catalog ConfigMaps")
+				cm1 := createLabeledConfigMap("extra-sources-a", true)
+				cm2 := createLabeledConfigMap("extra-sources-b", true)
+				Expect(k8sClient.Create(ctx, cm1)).To(Succeed())
+				Expect(k8sClient.Create(ctx, cm2)).To(Succeed())
+
+				By("Reconciling catalog resources")
+				_, err := catalogReconciler.ensureCatalogResources(ctx)
+				Expect(err).To(Not(HaveOccurred()))
+
+				By("Getting the deployment")
+				deployment := &appsv1.Deployment{}
+				Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name:      modelCatalogName,
+					Namespace: namespaceName,
+				}, deployment)).To(Succeed())
+
+				By("Verifying additional volumes exist")
+				volumeNames := make([]string, 0)
+				for _, v := range deployment.Spec.Template.Spec.Volumes {
+					volumeNames = append(volumeNames, v.Name)
+				}
+				Expect(volumeNames).To(ContainElement("labeled-extra-sources-a"))
+				Expect(volumeNames).To(ContainElement("labeled-extra-sources-b"))
+
+				By("Verifying additional volume mounts exist")
+				container := deployment.Spec.Template.Spec.Containers[0]
+				mountPaths := make([]string, 0)
+				for _, m := range container.VolumeMounts {
+					mountPaths = append(mountPaths, m.MountPath)
+				}
+				Expect(mountPaths).To(ContainElement("/data/labeled-sources/extra-sources-a"))
+				Expect(mountPaths).To(ContainElement("/data/labeled-sources/extra-sources-b"))
+
+				By("Verifying additional --catalogs-path args exist")
+				Expect(container.Args).To(ContainElement("--catalogs-path=/data/labeled-sources/extra-sources-a/sources.yaml"))
+				Expect(container.Args).To(ContainElement("--catalogs-path=/data/labeled-sources/extra-sources-b/sources.yaml"))
+			})
+
+			It("Should order labeled ConfigMaps alphabetically", func() {
+				By("Creating labeled ConfigMaps in non-alphabetical order")
+				for _, name := range []string{"z-sources", "a-sources", "m-sources"} {
+					Expect(k8sClient.Create(ctx, createLabeledConfigMap(name, true))).To(Succeed())
+				}
+
+				By("Discovering labeled sources")
+				sources, err := catalogReconciler.discoverLabeledSources(ctx)
+				Expect(err).To(Not(HaveOccurred()))
+				Expect(sources).To(HaveLen(3))
+				Expect(sources[0].Name).To(Equal("a-sources"))
+				Expect(sources[1].Name).To(Equal("m-sources"))
+				Expect(sources[2].Name).To(Equal("z-sources"))
+			})
+
+			It("Should skip labeled ConfigMaps missing sources.yaml key", func() {
+				By("Creating a labeled ConfigMap without sources.yaml")
+				Expect(k8sClient.Create(ctx, createLabeledConfigMap("no-sources-key", false))).To(Succeed())
+				By("Creating a labeled ConfigMap with sources.yaml")
+				Expect(k8sClient.Create(ctx, createLabeledConfigMap("has-sources-key", true))).To(Succeed())
+
+				By("Discovering labeled sources")
+				sources, err := catalogReconciler.discoverLabeledSources(ctx)
+				Expect(err).To(Not(HaveOccurred()))
+				Expect(sources).To(HaveLen(1))
+				Expect(sources[0].Name).To(Equal("has-sources-key"))
+			})
+
+			It("Should not include labeled ConfigMaps in existing deployment without labeled sources", func() {
+				By("Reconciling without any labeled ConfigMaps")
+				_, err := catalogReconciler.ensureCatalogResources(ctx)
+				Expect(err).To(Not(HaveOccurred()))
+
+				deployment := &appsv1.Deployment{}
+				Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name:      modelCatalogName,
+					Namespace: namespaceName,
+				}, deployment)).To(Succeed())
+
+				for _, v := range deployment.Spec.Template.Spec.Volumes {
+					Expect(v.Name).NotTo(HavePrefix("labeled-"))
+				}
+				for _, m := range deployment.Spec.Template.Spec.Containers[0].VolumeMounts {
+					Expect(m.MountPath).NotTo(HavePrefix("/data/labeled-sources/"))
+				}
+				for _, arg := range deployment.Spec.Template.Spec.Containers[0].Args {
+					Expect(arg).NotTo(HavePrefix("--catalogs-path=/data/labeled-sources/"))
+				}
+			})
+
+			It("Should update deployment when a labeled ConfigMap is added after initial reconcile", func() {
+				By("Reconciling without any labeled ConfigMaps")
+				_, err := catalogReconciler.ensureCatalogResources(ctx)
+				Expect(err).To(Not(HaveOccurred()))
+
+				By("Creating a labeled ConfigMap")
+				Expect(k8sClient.Create(ctx, createLabeledConfigMap("late-addition", true))).To(Succeed())
+
+				By("Reconciling again")
+				_, err = catalogReconciler.ensureCatalogResources(ctx)
+				Expect(err).To(Not(HaveOccurred()))
+
+				deployment := &appsv1.Deployment{}
+				Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name:      modelCatalogName,
+					Namespace: namespaceName,
+				}, deployment)).To(Succeed())
+
+				volumeNames := make([]string, 0)
+				for _, v := range deployment.Spec.Template.Spec.Volumes {
+					volumeNames = append(volumeNames, v.Name)
+				}
+				Expect(volumeNames).To(ContainElement("labeled-late-addition"))
+				Expect(deployment.Spec.Template.Spec.Containers[0].Args).To(
+					ContainElement("--catalogs-path=/data/labeled-sources/late-addition/sources.yaml"))
+			})
+
+			It("Should remove volumes and args when a labeled ConfigMap is deleted", func() {
+				By("Creating a labeled ConfigMap")
+				cm := createLabeledConfigMap("to-be-removed", true)
+				Expect(k8sClient.Create(ctx, cm)).To(Succeed())
+
+				By("Reconciling with the labeled ConfigMap present")
+				_, err := catalogReconciler.ensureCatalogResources(ctx)
+				Expect(err).To(Not(HaveOccurred()))
+
+				deployment := &appsv1.Deployment{}
+				Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name:      modelCatalogName,
+					Namespace: namespaceName,
+				}, deployment)).To(Succeed())
+				volumeNames := make([]string, 0)
+				for _, v := range deployment.Spec.Template.Spec.Volumes {
+					volumeNames = append(volumeNames, v.Name)
+				}
+				Expect(volumeNames).To(ContainElement("labeled-to-be-removed"))
+
+				By("Deleting the labeled ConfigMap")
+				Expect(k8sClient.Delete(ctx, cm)).To(Succeed())
+
+				By("Reconciling after deletion")
+				_, err = catalogReconciler.ensureCatalogResources(ctx)
+				Expect(err).To(Not(HaveOccurred()))
+
+				Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name:      modelCatalogName,
+					Namespace: namespaceName,
+				}, deployment)).To(Succeed())
+
+				for _, v := range deployment.Spec.Template.Spec.Volumes {
+					Expect(v.Name).NotTo(Equal("labeled-to-be-removed"))
+				}
+				for _, arg := range deployment.Spec.Template.Spec.Containers[0].Args {
+					Expect(arg).NotTo(Equal("--catalogs-path=/data/labeled-sources/to-be-removed/sources.yaml"))
+				}
+			})
+		})
+
 		Context("removeDefaultSource function", func() {
 			It("Should remove default catalog from YAML with multiple catalogs", func() {
 				input := `catalogs:


### PR DESCRIPTION
## Description

Adds label-based discovery of user-defined ConfigMaps to work around the 1MB ConfigMap size limit. Administrators can now label any ConfigMap with `opendatahub.io/catalog-source=true` to have it automatically mounted into the catalog deployment as an additional `--catalogs-path` source.

Each labeled ConfigMap must contain a `sources.yaml` data key. Discovered ConfigMaps mount at `/data/labeled-sources/<name>/` and load after the existing default and user-managed sources, giving them the highest precedence. Multiple labeled ConfigMaps load in alphabetical order.

Closes RHOAIENG-46741

## How Has This Been Tested?
Tested on a dev cluster. Created a new configmap with a `opendatahub.io/catalog-source="true"` label. Verified that the container args contain the new reference:

```
containers:
  - args:
    ...
    - --catalogs-path=/data/labeled-sources/labeled-source-test/sources.yaml
    ...
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic discovery of ConfigMaps labeled opendatahub.io/catalog-source=true (with sources.yaml); each discovered source is mounted into the catalog deployment and added to the catalog command arguments.

* **Bug Fixes**
  * Manager cache now includes all ConfigMaps in the configured target namespace, improving ConfigMap visibility for reconciliations.

* **Tests**
  * Added tests for discovery, deterministic ordering, add/remove behavior, and deployment updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->