### PR TITLE
fix(test): stop nil dereference and fix envtest binary path in config suite

### DIFF
--- a/internal/controller/config/defaults_test.go
+++ b/internal/controller/config/defaults_test.go
@@ -277,7 +277,7 @@ func TestKubeRBACProxyDeploymentGeneration(t *testing.T) {
 		}
 
 		if kubeRBACProxyContainer == nil {
-			t.Errorf("kube-rbac-proxy container should be present in deployment")
+			t.Fatalf("kube-rbac-proxy container should be present in deployment")
 		}
 
 		// Check kube-rbac-proxy specific arguments

--- a/internal/controller/config/suite_test.go
+++ b/internal/controller/config/suite_test.go
@@ -104,7 +104,7 @@ var _ = BeforeSuite(func() {
 		// default path defined in controller-runtime which is /usr/local/kubebuilder/.
 		// Note that you must have the required binaries setup under the bin directory to perform
 		// the tests directly. When we run make test it will be setup and used automatically.
-		BinaryAssetsDirectory: filepath.Join("..", "..", "bin", "k8s",
+		BinaryAssetsDirectory: filepath.Join("..", "..", "..", "bin", "k8s",
 			fmt.Sprintf("1.35.0-%s-%s", runtime.GOOS, runtime.GOARCH)),
 		UseExistingCluster: &useExistingCluster,
 	}


### PR DESCRIPTION
## Description

Two test fixes in `internal/controller/config/`:

1. **Nil guard** (`defaults_test.go`): Replace `t.Errorf` with `t.Fatalf` when `kube-rbac-proxy` container is absent in `TestKubeRBACProxyDeploymentGeneration`. Without this, the test logs the error and continues, causing a nil pointer dereference on subsequent lines. Closes #474.

2. **Envtest binary path** (`suite_test.go`): Fix `BinaryAssetsDirectory` to use `../../..` instead of `../..`. This package is one level deeper than all other test suites, so `../..` resolved to `internal/` rather than the repo root, causing envtest to fail with "no such file or directory" on `go test`.

## How Has This Been Tested?

`go test ./...` passes across all packages.

## Merge criteria:

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Tests now abort immediately when a required test component is missing, preventing misleading follow-up checks.
  * Test environment configuration updated so standalone test runs locate control-plane binaries correctly, improving reliability when running the suite outside the standard build target.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->