### PR TITLE
feat(catalog): add Partner and Community MCP catalog sources

### DIFF
--- a/internal/controller/config/templates/catalog/catalog-default-configmap.yaml.tmpl
+++ b/internal/controller/config/templates/catalog/catalog-default-configmap.yaml.tmpl
@@ -51,7 +51,11 @@ data:
       - name: Red Hat
         assetType: mcp_servers
         displayName: Red Hat MCP servers
-        description: Official Red Hat MCP servers with full support.
+        description: Official Red Hat MCP servers with support.
+      - name: Red Hat Partners
+        assetType: mcp_servers
+        displayName: Red Hat Partner MCP servers
+        description: A collection of Red Hat Partner MCP servers.
     namedQueries:
       default-performance-filters:
         "artifacts.use_case.string_value":
@@ -72,3 +76,17 @@ data:
           yamlCatalogPath: /shared-data/redhat-mcp-servers-catalog.yaml
         labels:
           - Red Hat
+      - name: Red Hat Partner MCP Servers
+        id: rh_partner_mcp_servers
+        type: yaml
+        enabled: true
+        properties:
+          yamlCatalogPath: /shared-data/partner-mcp-servers-catalog.yaml
+        labels:
+          - Red Hat Partners
+      - name: Community MCP Servers
+        id: community_mcp_servers
+        type: yaml
+        enabled: true
+        properties:
+          yamlCatalogPath: /shared-data/community-mcp-servers-catalog.yaml

--- a/internal/controller/modelcatalog_controller_test.go
+++ b/internal/controller/modelcatalog_controller_test.go
@@ -755,7 +755,7 @@ var _ = Describe("ModelCatalog controller", func() {
 				Expect(defaultSources).To(HaveKey("mcp_catalogs"))
 				mcpCatalogs, ok := defaultSources["mcp_catalogs"].([]any)
 				Expect(ok).To(BeTrue(), "mcp_catalogs should be an array")
-				Expect(mcpCatalogs).To(HaveLen(1))
+				Expect(mcpCatalogs).To(HaveLen(3), "mcp_catalogs should contain Red Hat, Partner, and Community entries")
 				mcpEntry, ok := mcpCatalogs[0].(map[string]any)
 				Expect(ok).To(BeTrue())
 				Expect(mcpEntry["name"]).To(Equal("Red Hat MCP Servers"))
@@ -768,6 +768,31 @@ var _ = Describe("ModelCatalog controller", func() {
 				mcpLabels, ok := mcpEntry["labels"].([]any)
 				Expect(ok).To(BeTrue())
 				Expect(mcpLabels).To(ContainElement("Red Hat"))
+
+				By("Verifying default sources ConfigMap contains Partner MCP catalog entry")
+				partnerEntry, ok := mcpCatalogs[1].(map[string]any)
+				Expect(ok).To(BeTrue())
+				Expect(partnerEntry["name"]).To(Equal("Red Hat Partner MCP Servers"))
+				Expect(partnerEntry["id"]).To(Equal("rh_partner_mcp_servers"))
+				Expect(partnerEntry["type"]).To(Equal("yaml"))
+				Expect(partnerEntry["enabled"]).To(BeTrue())
+				partnerProps, ok := partnerEntry["properties"].(map[string]any)
+				Expect(ok).To(BeTrue())
+				Expect(partnerProps["yamlCatalogPath"]).To(Equal("/shared-data/partner-mcp-servers-catalog.yaml"))
+				partnerLabels, ok := partnerEntry["labels"].([]any)
+				Expect(ok).To(BeTrue())
+				Expect(partnerLabels).To(ContainElement("Red Hat Partners"))
+
+				By("Verifying default sources ConfigMap contains Community MCP catalog entry")
+				communityEntry, ok := mcpCatalogs[2].(map[string]any)
+				Expect(ok).To(BeTrue())
+				Expect(communityEntry["name"]).To(Equal("Community MCP Servers"))
+				Expect(communityEntry["id"]).To(Equal("community_mcp_servers"))
+				Expect(communityEntry["type"]).To(Equal("yaml"))
+				Expect(communityEntry["enabled"]).To(BeTrue())
+				communityProps, ok := communityEntry["properties"].(map[string]any)
+				Expect(ok).To(BeTrue())
+				Expect(communityProps["yamlCatalogPath"]).To(Equal("/shared-data/community-mcp-servers-catalog.yaml"))
 
 				By("Verifying default sources ConfigMap contains MCP label definition with assetType")
 				labels, ok := defaultSources["labels"].([]any)
@@ -783,6 +808,18 @@ var _ = Describe("ModelCatalog controller", func() {
 				Expect(mcpLabel).To(Not(BeNil()), "should have a 'Red Hat' label definition")
 				Expect(mcpLabel["assetType"]).To(Equal("mcp_servers"))
 				Expect(mcpLabel["displayName"]).To(Equal("Red Hat MCP servers"))
+
+				var partnerLabel map[string]any
+				for _, l := range labels {
+					labelMap, ok := l.(map[string]any)
+					if ok && labelMap["name"] == "Red Hat Partners" {
+						partnerLabel = labelMap
+						break
+					}
+				}
+				Expect(partnerLabel).To(Not(BeNil()), "should have a 'Red Hat Partners' label definition")
+				Expect(partnerLabel["assetType"]).To(Equal("mcp_servers"))
+				Expect(partnerLabel["displayName"]).To(Equal("Red Hat Partner MCP servers"))
 
 				By("Verifying model labels have assetType set to models")
 				labelIndex := make(map[string]map[string]any)


### PR DESCRIPTION
## Description
Add two new MCP catalog source entries to the default sources ConfigMap:
- Red Hat Partner MCP Servers (rh_partner_mcp_servers)
- Community MCP Servers (community_mcp_servers)

Add a "Red Hat Partners" label definition with assetType mcp_servers to support filtering partner catalog entries.

Include corresponding test assertions verifying the new catalog entries (name, id, type, enabled, properties) and the partner label definition (assetType, displayName).

## How Has This Been Tested?
Unit tests

Stopped the operator to avoid reconcile then updated the `model-catalog-default-sources` with the updated configmap content. Then restarted the catalog deployment to consume the new sources. You can see the results here:

<img width="1883" height="1000" alt="image" src="https://github.com/user-attachments/assets/65a21acc-83ca-460a-af91-f8413742fafa" />

<img width="1678" height="635" alt="image" src="https://github.com/user-attachments/assets/3949c617-ec9a-4ec0-8af7-b6550f937d9c" />

<img width="1267" height="614" alt="image" src="https://github.com/user-attachments/assets/098e2ec3-0387-4f98-a29a-00b85cb07494" />

<img width="1867" height="974" alt="image" src="https://github.com/user-attachments/assets/27d39ab8-a05c-49b1-a7c9-7794496ad40b" />

<img width="1866" height="976" alt="image" src="https://github.com/user-attachments/assets/3f6ec552-d8b5-47a2-85b1-00371a3e1c0e" />


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Red Hat Partner MCP Servers catalog for partner-provided integrations
  * Added Community MCP Servers catalog to support community contributions

* **Updates**
  * Updated Red Hat MCP servers label description

<!-- end of auto-generated comment: release notes by coderabbit.ai -->