### PR TITLE
fix: allow traffic to kube-rbac-proxy from the dashboard

### DIFF
--- a/internal/controller/config/templates/catalog/catalog-kube-rbac-proxy-network-policy.yaml.tmpl
+++ b/internal/controller/config/templates/catalog/catalog-kube-rbac-proxy-network-policy.yaml.tmpl
@@ -18,6 +18,9 @@ spec:
     - namespaceSelector:
         matchLabels:
           network.openshift.io/policy-group: ingress
+    - namespaceSelector:
+        matchLabels:
+          opendatahub.io/generated-namespace: "true"
     ports:
       - protocol: TCP
         {{- if .Spec.KubeRBACProxy}}

--- a/internal/controller/config/templates/kube-rbac-proxy/kube-rbac-proxy-network-policy.yaml.tmpl
+++ b/internal/controller/config/templates/kube-rbac-proxy/kube-rbac-proxy-network-policy.yaml.tmpl
@@ -18,6 +18,9 @@ spec:
     - namespaceSelector:
         matchLabels:
           network.openshift.io/policy-group: ingress
+    - namespaceSelector:
+        matchLabels:
+          opendatahub.io/generated-namespace: "true"
     ports:
       - protocol: TCP
         {{- if .Spec.KubeRBACProxy}}


### PR DESCRIPTION
## Description

Update the NetworkPolicies to allow traffic from the ODH/RHOAI namespaces to the kube-rbac-proxy port.

## How Has This Been Tested?
I tested the connection from a shell on one of the dashboard pods (e.g. `oc exec -n redhat-ods-applications -it rhods-dashboard-dff85f7c7-x6crm -- bash -l`).

Before the change:

```sh
[1000850000@rhods-dashboard-dff85f7c7-x6crm backend]$ curl --connect-timeout 10 https://model-catalog.rhoai-model-registries.svc.cluster.local:8443
curl: (28) Connection timed out after 10001 milliseconds
```

And after:

```sh
[1000850000@rhods-dashboard-dff85f7c7-x6crm backend]$ curl -k --connect-timeout 10 https://model-catalog.rhoai-model-registries.svc.cluster.local:8443
Unauthorized
```

(The request still didn't work because there wasn't an auth token, but it didn't timeout.)

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * NetworkPolicy ingress selectors updated to also allow traffic from namespaces labeled opendatahub.io/generated-namespace: "true", while retaining existing OpenShift ingress selectors. This expands allowed ingress sources for affected components without changing ports, pod selectors, or policy types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->