### PR TITLE
Reapply "feat(catalog): rename default sources ConfigMap to default-catalog-sources (#489)" (#500)

### DIFF
--- a/internal/controller/config/templates/catalog/catalog-default-configmap.yaml.tmpl
+++ b/internal/controller/config/templates/catalog/catalog-default-configmap.yaml.tmpl
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: "model-catalog-default-sources"
+  name: "default-catalog-sources"
   namespace: {{.Namespace}}
   labels:
     app: {{.Name}}

--- a/internal/controller/config/templates/catalog/catalog-deployment.yaml.tmpl
+++ b/internal/controller/config/templates/catalog/catalog-deployment.yaml.tmpl
@@ -41,7 +41,7 @@ spec:
           name: mcp-catalog-sources
       - name: default-sources
         configMap:
-          name: model-catalog-default-sources
+          name: default-catalog-sources
       - name: catalog-data
         emptyDir: {}
       - name: benchmark-data

--- a/internal/controller/modelcatalog_controller.go
+++ b/internal/controller/modelcatalog_controller.go
@@ -162,6 +162,18 @@ func (r *ModelCatalogReconciler) ensureCatalogResources(ctx context.Context) (ct
 		result = result2
 	}
 
+	// Delete the old-named default sources ConfigMap (renamed 2026-04, was "model-catalog-default-sources").
+	// Remove once old clusters have had enough time to reconcile.
+	var oldDefaultCM corev1.ConfigMap
+	err = r.Get(ctx, types.NamespacedName{Name: "model-catalog-default-sources", Namespace: r.TargetNamespace}, &oldDefaultCM)
+	if client.IgnoreNotFound(err) != nil {
+		log.Error(err, "failed to get legacy default sources ConfigMap")
+	} else if err == nil && oldDefaultCM.Labels["app.kubernetes.io/created-by"] == "model-registry-operator" {
+		if delErr := r.Delete(ctx, &oldDefaultCM); client.IgnoreNotFound(delErr) != nil {
+			log.Error(delErr, "failed to delete legacy default sources ConfigMap")
+		}
+	}
+
 	// Create the user-managed sources ConfigMap if it doesn't exist
 	result2, err = r.manageUserSourcesConfigmap(ctx, catalogParams, "catalog-configmap.yaml.tmpl")
 	if err != nil {

--- a/internal/controller/modelcatalog_controller_test.go
+++ b/internal/controller/modelcatalog_controller_test.go
@@ -736,7 +736,7 @@ var _ = Describe("ModelCatalog controller", func() {
 				By("Checking if the default sources ConfigMap was created")
 				defaultConfigMap := &corev1.ConfigMap{}
 				err = k8sClient.Get(ctx, types.NamespacedName{
-					Name:      "model-catalog-default-sources",
+					Name:      "default-catalog-sources",
 					Namespace: namespaceName,
 				}, defaultConfigMap)
 				Expect(err).To(Not(HaveOccurred()))
@@ -847,7 +847,7 @@ var _ = Describe("ModelCatalog controller", func() {
 				By("Getting the default sources ConfigMap")
 				defaultConfigMap := &corev1.ConfigMap{}
 				err = k8sClient.Get(ctx, types.NamespacedName{
-					Name:      "model-catalog-default-sources",
+					Name:      "default-catalog-sources",
 					Namespace: namespaceName,
 				}, defaultConfigMap)
 				Expect(err).To(Not(HaveOccurred()))
@@ -863,12 +863,42 @@ var _ = Describe("ModelCatalog controller", func() {
 
 				By("Verifying the ConfigMap was restored to the expected state")
 				err = k8sClient.Get(ctx, types.NamespacedName{
-					Name:      "model-catalog-default-sources",
+					Name:      "default-catalog-sources",
 					Namespace: namespaceName,
 				}, defaultConfigMap)
 				Expect(err).To(Not(HaveOccurred()))
 				Expect(defaultConfigMap.Data["sources.yaml"]).To(ContainSubstring("Red Hat AI"))
 				Expect(defaultConfigMap.Data["sources.yaml"]).To(ContainSubstring("redhat_ai_models"))
+			})
+
+			It("Should delete the old-named default sources ConfigMap on reconcile", func() {
+				By("Creating the old-named ConfigMap")
+				oldCM := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "model-catalog-default-sources",
+						Namespace: namespaceName,
+						Labels: map[string]string{
+							"app.kubernetes.io/created-by": "model-registry-operator",
+						},
+					},
+					Data: map[string]string{"sources.yaml": "catalogs: []"},
+				}
+				err := k8sClient.Create(ctx, oldCM)
+				Expect(err).To(Not(HaveOccurred()))
+
+				By("Running reconciliation")
+				_, err = catalogReconciler.ensureCatalogResources(ctx)
+				Expect(err).To(Not(HaveOccurred()))
+
+				By("Verifying the old ConfigMap is gone")
+				gone := &corev1.ConfigMap{}
+				err = k8sClient.Get(ctx, types.NamespacedName{Name: "model-catalog-default-sources", Namespace: namespaceName}, gone)
+				Expect(apierrors.IsNotFound(err)).To(BeTrue(), "old ConfigMap should have been deleted")
+
+				By("Verifying the new ConfigMap still exists")
+				newCM := &corev1.ConfigMap{}
+				err = k8sClient.Get(ctx, types.NamespacedName{Name: "default-catalog-sources", Namespace: namespaceName}, newCM)
+				Expect(err).To(Not(HaveOccurred()))
 			})
 
 			It("Should not modify user sources ConfigMap if it has no default catalog", func() {
@@ -959,7 +989,7 @@ var _ = Describe("ModelCatalog controller", func() {
 				By("Verifying the default sources ConfigMap was still created")
 				defaultConfigMap := &corev1.ConfigMap{}
 				err = k8sClient.Get(ctx, types.NamespacedName{
-					Name:      "model-catalog-default-sources",
+					Name:      "default-catalog-sources",
 					Namespace: namespaceName,
 				}, defaultConfigMap)
 				Expect(err).To(Not(HaveOccurred()))
@@ -1011,7 +1041,7 @@ catalogs:
 				By("Verifying default sources ConfigMap was still created")
 				defaultConfigMap := &corev1.ConfigMap{}
 				err = k8sClient.Get(ctx, types.NamespacedName{
-					Name:      "model-catalog-default-sources",
+					Name:      "default-catalog-sources",
 					Namespace: namespaceName,
 				}, defaultConfigMap)
 				Expect(err).To(Not(HaveOccurred()))
@@ -1026,7 +1056,7 @@ catalogs:
 				By("Getting the default sources ConfigMap")
 				defaultConfigMap := &corev1.ConfigMap{}
 				err = k8sClient.Get(ctx, types.NamespacedName{
-					Name:      "model-catalog-default-sources",
+					Name:      "default-catalog-sources",
 					Namespace: namespaceName,
 				}, defaultConfigMap)
 				Expect(err).To(Not(HaveOccurred()))
@@ -1076,7 +1106,7 @@ catalogs:
 				Expect(userMcpSourcesVolume.ConfigMap.Name).To(Equal("mcp-catalog-sources"))
 
 				Expect(defaultSourcesVolume).To(Not(BeNil()), "default-sources volume should exist")
-				Expect(defaultSourcesVolume.ConfigMap.Name).To(Equal("model-catalog-default-sources"))
+				Expect(defaultSourcesVolume.ConfigMap.Name).To(Equal("default-catalog-sources"))
 
 				By("Verifying catalog container has all volume mounts")
 				catalogContainer := deployment.Spec.Template.Spec.Containers[0]


### PR DESCRIPTION
## Description

These are the changes from #489, which were reverted in #500.

## How Has This Been Tested?

Same as #489:

> On a dev cluster, I confirmed that the configmap is called default-catalog-sources, the model catalog pod used it, and that model-catalog-default-sources no longer exists.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Renamed default catalog configuration source names for improved naming consistency.
  * Added automatic cleanup of legacy configuration resources during system initialization to ensure a clean state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->