### PR TITLE
feat(chaos): integrate operator-chaos shift-left validation for L1-L3 maturity

### DIFF
--- a/.github/workflows/chaos-validate.yml
+++ b/.github/workflows/chaos-validate.yml
@@ -1,0 +1,60 @@
+name: Chaos Validation
+
+on:
+  pull_request:
+    paths:
+      - 'chaos/**'
+      - 'internal/controller/**'
+      - 'api/**'
+      - 'config/**'
+      - 'go.mod'
+      - 'go.sum'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Install operator-chaos
+        run: go install github.com/opendatahub-io/operator-chaos/cmd/operator-chaos@v0.0.0-20260521100204-4dab974d613c
+
+      - name: Validate knowledge model
+        run: operator-chaos validate --knowledge chaos/knowledge/model-registry.yaml
+
+      - name: Local preflight
+        run: operator-chaos preflight --knowledge chaos/knowledge/model-registry.yaml --local
+
+      - name: Validate all experiments
+        run: |
+          status=0
+          for f in chaos/experiments/*.yaml; do
+            echo "--- $f ---"
+            if ! operator-chaos validate "$f"; then
+              status=1
+            fi
+          done
+          exit "$status"
+
+      - name: Checkout base branch knowledge
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: base-branch
+          sparse-checkout: chaos/knowledge
+
+      - name: Detect breaking changes
+        run: |
+          if [ -d "base-branch/chaos/knowledge" ]; then
+            operator-chaos diff --source base-branch/chaos/knowledge --target chaos/knowledge --breaking
+          else
+            echo "No base knowledge model found — skipping diff (first-time integration)"
+          fi
+
+      - name: Run chaos tests
+        run: make test-chaos

--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,22 @@ lint: golangci-lint ## Run golangci-lint against code.
 test: manifests generate fmt vet govulncheck envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./... -coverprofile cover.out
 
+.PHONY: test-chaos
+test-chaos: envtest ## Run chaos resilience tests.
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./internal/controller/... -v -count=1 --ginkgo.focus="chaos"
+
+.PHONY: chaos-validate
+chaos-validate: operator-chaos ## Validate chaos knowledge model and experiments.
+	$(OPERATOR_CHAOS) validate --knowledge chaos/knowledge/model-registry.yaml
+	@status=0; \
+	for f in chaos/experiments/*.yaml; do \
+		echo "--- $$f ---"; \
+		if ! $(OPERATOR_CHAOS) validate "$$f"; then \
+			status=1; \
+		fi; \
+	done; \
+	exit $$status
+
 ##@ Build
 
 .PHONY: build
@@ -202,6 +218,8 @@ GOVULNCHECK ?= $(LOCALBIN)/govulncheck
 GOVULNCHECK_VERSION ?= v1.1.4
 GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint
 GOLANGCI_LINT_VERSION ?= v2.1.6
+OPERATOR_CHAOS ?= $(LOCALBIN)/operator-chaos
+OPERATOR_CHAOS_VERSION ?= v0.0.0-20260521100204-4dab974d613c
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.1.1
@@ -253,6 +271,11 @@ $(GOLANGCI_LINT): $(LOCALBIN)
 		rm -rf $(LOCALBIN)/golangci-lint; \
 	fi
 	test -s $(LOCALBIN)/golangci-lint || GOBIN=$(LOCALBIN) go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
+
+.PHONY: operator-chaos
+operator-chaos: $(OPERATOR_CHAOS) ## Download operator-chaos locally if necessary.
+$(OPERATOR_CHAOS): $(LOCALBIN)
+	test -s $(LOCALBIN)/operator-chaos || GOBIN=$(LOCALBIN) go install github.com/opendatahub-io/operator-chaos/cmd/operator-chaos@$(OPERATOR_CHAOS_VERSION)
 
 .PHONY: certificates
 certificates: certificates/clean

--- a/chaos/experiments/catalog-config-drift.yaml
+++ b/chaos/experiments/catalog-config-drift.yaml
@@ -1,0 +1,37 @@
+apiVersion: chaos.operatorchaos.io/v1alpha1
+kind: ChaosExperiment
+metadata:
+  name: model-catalog-config-drift
+spec:
+  target:
+    operator: model-registry
+    component: model-catalog
+    resource: ConfigMap/model-catalog-sources-default
+  steadyState:
+    checks:
+      - type: conditionTrue
+        apiVersion: apps/v1
+        kind: Deployment
+        name: model-catalog
+        namespace: odh-model-registries
+        conditionType: Available
+    timeout: "30s"
+  injection:
+    type: ConfigDrift
+    parameters:
+      name: model-catalog-sources-default
+      key: chaos-injected
+      value: "true"
+    ttl: "120s"
+  hypothesis:
+    description: >-
+      When the model-catalog default sources ConfigMap is mutated with an
+      unexpected key, the ModelCatalog reconciler should detect the drift
+      on its next reconcile loop and restore the ConfigMap to its expected
+      state. The chaos framework removes the injected field via TTL-based
+      cleanup after 120s.
+    recoveryTimeout: 180s
+  blastRadius:
+    maxPodsAffected: 1
+    allowedNamespaces:
+      - odh-model-registries

--- a/chaos/experiments/catalog-config-drift.yaml
+++ b/chaos/experiments/catalog-config-drift.yaml
@@ -6,7 +6,7 @@ spec:
   target:
     operator: model-registry
     component: model-catalog
-    resource: ConfigMap/model-catalog-sources-default
+    resource: ConfigMap/default-catalog-sources
   steadyState:
     checks:
       - type: conditionTrue
@@ -19,7 +19,7 @@ spec:
   injection:
     type: ConfigDrift
     parameters:
-      name: model-catalog-sources-default
+      name: default-catalog-sources
       key: chaos-injected
       value: "true"
     ttl: "120s"

--- a/chaos/experiments/catalog-pod-kill.yaml
+++ b/chaos/experiments/catalog-pod-kill.yaml
@@ -1,0 +1,36 @@
+apiVersion: chaos.operatorchaos.io/v1alpha1
+kind: ChaosExperiment
+metadata:
+  name: model-catalog-pod-kill
+spec:
+  target:
+    operator: model-registry
+    component: model-catalog
+    resource: Deployment/model-catalog
+  steadyState:
+    checks:
+      - type: conditionTrue
+        apiVersion: apps/v1
+        kind: Deployment
+        name: model-catalog
+        namespace: odh-model-registries
+        conditionType: Available
+    timeout: "30s"
+  injection:
+    type: PodKill
+    parameters:
+      labelSelector: app=model-catalog
+    count: 1
+    ttl: "300s"
+  hypothesis:
+    description: >-
+      When the model-catalog pod is killed, Kubernetes should recreate it
+      within the recovery timeout. The ModelCatalog reconciler should
+      re-converge all managed resources (Deployment, Service, ConfigMaps,
+      PostgreSQL) without data loss or catalog downtime beyond the pod
+      restart window.
+    recoveryTimeout: 120s
+  blastRadius:
+    maxPodsAffected: 1
+    allowedNamespaces:
+      - odh-model-registries

--- a/chaos/experiments/config-drift.yaml
+++ b/chaos/experiments/config-drift.yaml
@@ -1,0 +1,46 @@
+# IMPORTANT: "test-registry" is a placeholder. Replace it with the name
+# of an actual ModelRegistry resource deployed in the target namespace
+# before running this experiment.
+apiVersion: chaos.operatorchaos.io/v1alpha1
+kind: ChaosExperiment
+metadata:
+  name: model-registry-config-drift
+spec:
+  target:
+    operator: model-registry
+    component: model-registry-operator
+    resource: Deployment/model-registry-operator-controller-manager
+  steadyState:
+    checks:
+      - type: conditionTrue
+        apiVersion: apps/v1
+        kind: Deployment
+        name: model-registry-operator-controller-manager
+        namespace: odh-model-registries
+        conditionType: Available
+    timeout: "30s"
+  injection:
+    type: CRDMutation
+    dangerLevel: high
+    parameters:
+      apiVersion: modelregistry.opendatahub.io/v1beta1
+      kind: ModelRegistry
+      name: test-registry
+      field: chaosInjected
+      value: "true"
+    ttl: "120s"
+  hypothesis:
+    description: >-
+      When a ModelRegistry CR is mutated with an unknown field via merge
+      patch, the operator should reconcile without error and not propagate
+      the unknown field to downstream resources (Deployment, Service,
+      ConfigMap). This validates that the reconciler is resilient to
+      unexpected CR modifications — e.g. from errant automation, manual
+      edits, or version skew during upgrades. The chaos framework removes
+      the injected field via TTL-based cleanup after 120s.
+    recoveryTimeout: 180s
+  blastRadius:
+    maxPodsAffected: 1
+    allowedNamespaces:
+      - odh-model-registries
+    allowDangerous: true

--- a/chaos/experiments/finalizer-block.yaml
+++ b/chaos/experiments/finalizer-block.yaml
@@ -1,0 +1,41 @@
+# IMPORTANT: "test-registry" is a placeholder. Replace it with the name
+# of an actual ModelRegistry resource deployed in the target namespace
+# before running this experiment.
+apiVersion: chaos.operatorchaos.io/v1alpha1
+kind: ChaosExperiment
+metadata:
+  name: model-registry-finalizer-block
+spec:
+  target:
+    operator: model-registry
+    component: model-registry-operator
+    resource: ModelRegistry
+  steadyState:
+    checks:
+      - type: conditionTrue
+        apiVersion: apps/v1
+        kind: Deployment
+        name: model-registry-operator-controller-manager
+        namespace: odh-model-registries
+        conditionType: Available
+    timeout: "30s"
+  injection:
+    type: FinalizerBlock
+    parameters:
+      apiVersion: modelregistry.opendatahub.io/v1beta1
+      kind: ModelRegistry
+      name: test-registry
+      finalizer: modelregistry.opendatahub.io/finalizer
+    ttl: "300s"
+  hypothesis:
+    description: >-
+      When a stuck finalizer prevents a ModelRegistry from being deleted,
+      the operator should handle the Terminating state gracefully, report
+      the blocked deletion in its status, and not leak associated database
+      or service resources. The chaos framework removes the finalizer via
+      TTL-based cleanup after 300s.
+    recoveryTimeout: 180s
+  blastRadius:
+    maxPodsAffected: 1
+    allowedNamespaces:
+      - odh-model-registries

--- a/chaos/experiments/mutating-webhook-disrupt.yaml
+++ b/chaos/experiments/mutating-webhook-disrupt.yaml
@@ -1,0 +1,40 @@
+apiVersion: chaos.operatorchaos.io/v1alpha1
+kind: ChaosExperiment
+metadata:
+  name: model-registry-mutating-webhook-disrupt
+spec:
+  target:
+    operator: model-registry
+    component: model-registry-operator
+    resource: MutatingWebhookConfiguration/model-registry-operator-mutating-webhook-configuration
+  steadyState:
+    checks:
+      - type: conditionTrue
+        apiVersion: apps/v1
+        kind: Deployment
+        name: model-registry-operator-controller-manager
+        namespace: odh-model-registries
+        conditionType: Available
+    timeout: "30s"
+  injection:
+    type: WebhookDisrupt
+    dangerLevel: high
+    parameters:
+      webhookName: mmodelregistry.opendatahub.io
+      action: setFailurePolicy
+      value: Ignore
+    ttl: "60s"
+  hypothesis:
+    description: >-
+      When the ModelRegistry mutating webhook failurePolicy is weakened from
+      Fail to Ignore, ModelRegistry CRs can be created without defaults being
+      applied (e.g. missing database configuration, missing REST service
+      settings). The operator should handle CRs with missing defaulted fields
+      gracefully — either by applying defaults in the reconciler or by
+      reporting clear validation errors in status — rather than panicking or
+      creating partial deployments. The chaos framework restores the original
+      failurePolicy via TTL-based cleanup after 60s.
+    recoveryTimeout: 120s
+  blastRadius:
+    maxPodsAffected: 1
+    allowDangerous: true

--- a/chaos/experiments/network-partition.yaml
+++ b/chaos/experiments/network-partition.yaml
@@ -1,0 +1,34 @@
+apiVersion: chaos.operatorchaos.io/v1alpha1
+kind: ChaosExperiment
+metadata:
+  name: model-registry-network-partition
+spec:
+  target:
+    operator: model-registry
+    component: model-registry-operator
+    resource: Deployment/model-registry-operator-controller-manager
+  steadyState:
+    checks:
+      - type: conditionTrue
+        apiVersion: apps/v1
+        kind: Deployment
+        name: model-registry-operator-controller-manager
+        namespace: odh-model-registries
+        conditionType: Available
+    timeout: "30s"
+  injection:
+    type: NetworkPartition
+    parameters:
+      labelSelector: control-plane=model-registry-operator
+    ttl: "300s"
+  hypothesis:
+    description: >-
+      When the model-registry-operator pod is network-partitioned from
+      the API server, it should lose its leader lease and stop reconciling.
+      Once the partition is removed, the operator should re-acquire the
+      lease and resume normal operation.
+    recoveryTimeout: 180s
+  blastRadius:
+    maxPodsAffected: 1
+    allowedNamespaces:
+      - odh-model-registries

--- a/chaos/experiments/pod-kill.yaml
+++ b/chaos/experiments/pod-kill.yaml
@@ -1,0 +1,35 @@
+apiVersion: chaos.operatorchaos.io/v1alpha1
+kind: ChaosExperiment
+metadata:
+  name: model-registry-pod-kill
+spec:
+  target:
+    operator: model-registry
+    component: model-registry-operator
+    resource: Deployment/model-registry-operator-controller-manager
+  steadyState:
+    checks:
+      - type: conditionTrue
+        apiVersion: apps/v1
+        kind: Deployment
+        name: model-registry-operator-controller-manager
+        namespace: odh-model-registries
+        conditionType: Available
+    timeout: "30s"
+  injection:
+    type: PodKill
+    parameters:
+      labelSelector: control-plane=model-registry-operator
+    count: 1
+    ttl: "300s"
+  hypothesis:
+    description: >-
+      When the model-registry-operator pod is killed, Kubernetes should
+      recreate it within the recovery timeout. The operator should resume
+      reconciling ModelRegistry resources without data loss or registry
+      downtime.
+    recoveryTimeout: 120s
+  blastRadius:
+    maxPodsAffected: 1
+    allowedNamespaces:
+      - odh-model-registries

--- a/chaos/experiments/rbac-revoke.yaml
+++ b/chaos/experiments/rbac-revoke.yaml
@@ -1,0 +1,35 @@
+apiVersion: chaos.operatorchaos.io/v1alpha1
+kind: ChaosExperiment
+metadata:
+  name: model-registry-rbac-revoke
+spec:
+  target:
+    operator: model-registry
+    component: model-registry-operator
+    resource: ClusterRoleBinding/model-registry-operator-manager-rolebinding
+  steadyState:
+    checks:
+      - type: conditionTrue
+        apiVersion: apps/v1
+        kind: Deployment
+        name: model-registry-operator-controller-manager
+        namespace: odh-model-registries
+        conditionType: Available
+    timeout: "30s"
+  injection:
+    type: RBACRevoke
+    dangerLevel: high
+    parameters:
+      bindingName: model-registry-operator-manager-rolebinding
+      bindingType: ClusterRoleBinding
+    ttl: "60s"
+  hypothesis:
+    description: >-
+      When the model-registry-operator ClusterRoleBinding subjects are
+      revoked, the operator should lose its ability to manage ModelRegistry
+      instances and surface permission-denied errors. Once permissions are
+      restored, reconciliation should resume without manual intervention.
+    recoveryTimeout: 120s
+  blastRadius:
+    maxPodsAffected: 1
+    allowDangerous: true

--- a/chaos/experiments/webhook-disrupt.yaml
+++ b/chaos/experiments/webhook-disrupt.yaml
@@ -1,0 +1,36 @@
+apiVersion: chaos.operatorchaos.io/v1alpha1
+kind: ChaosExperiment
+metadata:
+  name: model-registry-webhook-disrupt
+spec:
+  target:
+    operator: model-registry
+    component: model-registry-operator
+    resource: ValidatingWebhookConfiguration/model-registry-operator-validating-webhook-configuration
+  steadyState:
+    checks:
+      - type: conditionTrue
+        apiVersion: apps/v1
+        kind: Deployment
+        name: model-registry-operator-controller-manager
+        namespace: odh-model-registries
+        conditionType: Available
+    timeout: "30s"
+  injection:
+    type: WebhookDisrupt
+    dangerLevel: high
+    parameters:
+      webhookName: vmodelregistry.opendatahub.io
+      action: setFailurePolicy
+      value: Ignore
+    ttl: "60s"
+  hypothesis:
+    description: >-
+      When the ModelRegistry validating webhook failurePolicy is weakened
+      from Fail to Ignore, invalid ModelRegistry resources can bypass
+      admission validation. The chaos framework restores the original
+      failurePolicy via TTL-based cleanup after 60s.
+    recoveryTimeout: 120s
+  blastRadius:
+    maxPodsAffected: 1
+    allowDangerous: true

--- a/chaos/knowledge/model-registry.yaml
+++ b/chaos/knowledge/model-registry.yaml
@@ -5,7 +5,7 @@ operator:
 
 components:
   - name: model-registry-operator
-    controller: DataScienceCluster
+    controller: ModelRegistryReconciler
     managedResources:
       - apiVersion: apps/v1
         kind: Deployment
@@ -71,7 +71,7 @@ components:
         namespace: odh-model-registries
       - apiVersion: v1
         kind: ConfigMap
-        name: model-catalog-sources-default
+        name: default-catalog-sources
         namespace: odh-model-registries
       - apiVersion: apps/v1
         kind: Deployment

--- a/chaos/knowledge/model-registry.yaml
+++ b/chaos/knowledge/model-registry.yaml
@@ -1,0 +1,102 @@
+operator:
+  name: model-registry
+  namespace: odh-model-registries
+  repository: https://github.com/opendatahub-io/model-registry-operator
+
+components:
+  - name: model-registry-operator
+    controller: DataScienceCluster
+    managedResources:
+      - apiVersion: apps/v1
+        kind: Deployment
+        name: model-registry-operator-controller-manager
+        namespace: odh-model-registries
+        labels:
+          control-plane: model-registry-operator
+          app.kubernetes.io/name: deployment
+        expectedSpec:
+          replicas: 1
+      - apiVersion: v1
+        kind: ServiceAccount
+        name: model-registry-operator-controller-manager
+        namespace: odh-model-registries
+      - apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRoleBinding
+        name: model-registry-operator-manager-rolebinding
+      - apiVersion: coordination.k8s.io/v1
+        kind: Lease
+        name: 85f368d1.opendatahub.io
+        namespace: odh-model-registries
+      - apiVersion: v1
+        kind: Service
+        name: model-registry-operator-controller-manager-metrics-service
+        namespace: odh-model-registries
+    webhooks:
+      - name: vmodelregistry.opendatahub.io
+        type: validating
+        path: /validate-modelregistry-opendatahub-io-modelregistry
+      - name: mmodelregistry.opendatahub.io
+        type: mutating
+        path: /mutate-modelregistry-opendatahub-io-modelregistry
+    finalizers:
+      - modelregistry.opendatahub.io/finalizer
+    steadyState:
+      checks:
+        - type: conditionTrue
+          apiVersion: apps/v1
+          kind: Deployment
+          name: model-registry-operator-controller-manager
+          namespace: odh-model-registries
+          conditionType: Available
+      timeout: "60s"
+
+  - name: model-catalog
+    controller: ModelCatalogReconciler
+    managedResources:
+      - apiVersion: apps/v1
+        kind: Deployment
+        name: model-catalog
+        namespace: odh-model-registries
+        labels:
+          app: model-catalog
+        expectedSpec:
+          replicas: 1
+      - apiVersion: v1
+        kind: Service
+        name: model-catalog
+        namespace: odh-model-registries
+      - apiVersion: v1
+        kind: ServiceAccount
+        name: model-catalog
+        namespace: odh-model-registries
+      - apiVersion: v1
+        kind: ConfigMap
+        name: model-catalog-sources-default
+        namespace: odh-model-registries
+      - apiVersion: apps/v1
+        kind: Deployment
+        name: model-catalog-postgres
+        namespace: odh-model-registries
+        labels:
+          app: model-catalog-postgres
+      - apiVersion: v1
+        kind: Service
+        name: model-catalog-postgres
+        namespace: odh-model-registries
+      - apiVersion: v1
+        kind: PersistentVolumeClaim
+        name: model-catalog-postgres
+        namespace: odh-model-registries
+    steadyState:
+      checks:
+        - type: conditionTrue
+          apiVersion: apps/v1
+          kind: Deployment
+          name: model-catalog
+          namespace: odh-model-registries
+          conditionType: Available
+      timeout: "60s"
+
+recovery:
+  reconcileTimeout: "300s"
+  maxReconcileCycles: 10

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/go-logr/logr v1.4.3
 	github.com/onsi/ginkgo/v2 v2.28.3
 	github.com/onsi/gomega v1.40.0
+	github.com/opendatahub-io/operator-chaos v0.0.0-20260521100204-4dab974d613c
 	github.com/openshift/api v0.0.0-20260320151444-324a1bcb9f55
 	istio.io/client-go v1.29.2
 	k8s.io/api v0.35.4
@@ -71,7 +72,7 @@ require (
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
-	github.com/spf13/cobra v1.10.0 // indirect
+	github.com/spf13/cobra v1.10.2 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/stoewer/go-strcase v1.3.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -196,6 +196,8 @@ github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGV
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.40.0 h1:Vtol0e1MghCD2ZVIilPDIg44XSL9l2QAn8ZNaljWcJc=
 github.com/onsi/gomega v1.40.0/go.mod h1:M/Uqpu/8qTjtzCLUA2zJHX9Iilrau25x1PdoSRbWh5A=
+github.com/opendatahub-io/operator-chaos v0.0.0-20260521100204-4dab974d613c h1:olKZNTyNTTaLVnGyNimB4nSihohMghshSoqDWfSmFwI=
+github.com/opendatahub-io/operator-chaos v0.0.0-20260521100204-4dab974d613c/go.mod h1:f9D+8VSCrpTB2EeGD6F26ZkaO8GN7dCbT9lFZfZ68t0=
 github.com/openshift/api v0.0.0-20260320151444-324a1bcb9f55 h1:2h6bqs9ua3wrsQnxEbzys3/n5IohLC7Dyb/KgaVYC/A=
 github.com/openshift/api v0.0.0-20260320151444-324a1bcb9f55/go.mod h1:pyVjK0nZ4sRs4fuQVQ4rubsJdahI1PB94LnQ8sGdvxo=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -215,11 +217,11 @@ github.com/prometheus/procfs v0.16.1/go.mod h1:teAbpZRB1iIAJYREa1LsoWUXykVXA1KlT
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/spf13/cobra v1.10.0 h1:a5/WeUlSDCvV5a45ljW2ZFtV0bTDpkfSAj3uqB6Sc+0=
-github.com/spf13/cobra v1.10.0/go.mod h1:9dhySC7dnTtEiqzmqfkLj47BslqLCUPMXjG2lj/NgoE=
+github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
+github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
 github.com/spf13/pflag v0.0.0-20170130214245-9ff6c6923cff/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
-github.com/spf13/pflag v1.0.8/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
 github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stoewer/go-strcase v1.3.0 h1:g0eASXYtp+yvN9fK8sH94oCIk0fau9uV1/ZdJ0AVEzs=

--- a/internal/controller/modelregistry_chaos_test.go
+++ b/internal/controller/modelregistry_chaos_test.go
@@ -1,0 +1,450 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"text/template"
+	"time"
+
+	"github.com/opendatahub-io/model-registry-operator/api/v1beta1"
+	"github.com/opendatahub-io/model-registry-operator/internal/controller/config"
+	"github.com/opendatahub-io/operator-chaos/pkg/sdk"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbac "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/events"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func initChaosReconciler(tmpl *template.Template, cfg *sdk.FaultConfig) *ModelRegistryReconciler {
+	chaosClient := sdk.NewChaosClient(k8sClient, cfg)
+
+	return &ModelRegistryReconciler{
+		Client:   chaosClient,
+		Scheme:   k8sClient.Scheme(),
+		Recorder: &events.FakeRecorder{},
+		Log:      ctrl.Log.WithName("chaos-test"),
+		Template: tmpl,
+		Capabilities: ClusterCapabilities{
+			IsOpenShift:  false,
+			HasUserAPI:   false,
+			HasConfigAPI: false,
+		},
+	}
+}
+
+func initCatalogChaosReconciler(tmpl *template.Template, cfg *sdk.FaultConfig, targetNamespace string) *ModelCatalogReconciler {
+	chaosClient := sdk.NewChaosClient(k8sClient, cfg)
+
+	return &ModelCatalogReconciler{
+		Client:          chaosClient,
+		Scheme:          k8sClient.Scheme(),
+		Recorder:        &events.FakeRecorder{},
+		Log:             ctrl.Log.WithName("chaos-test-catalog"),
+		Template:        tmpl,
+		TargetNamespace: targetNamespace,
+		Enabled:         true,
+		Capabilities:    ClusterCapabilities{},
+	}
+}
+
+var _ = Describe("ModelRegistry chaos resilience", func() {
+
+	ctx := context.Background()
+
+	var chaosTemplate *template.Template
+
+	BeforeEach(func() {
+		err := os.Setenv(config.RestImage, config.DefaultRestImage)
+		Expect(err).NotTo(HaveOccurred())
+		err = os.Setenv(config.PostgresImage, config.DefaultPostgresImage)
+		Expect(err).NotTo(HaveOccurred())
+		err = os.Setenv(config.KubeRBACProxyImage, config.DefaultKubeRBACProxyImage)
+		Expect(err).NotTo(HaveOccurred())
+
+		var parseErr error
+		chaosTemplate, parseErr = config.ParseTemplates()
+		Expect(parseErr).NotTo(HaveOccurred())
+	})
+
+	Describe("reconciler under API faults", func() {
+
+		var (
+			namespace         *corev1.Namespace
+			typeNamespaceName types.NamespacedName
+		)
+
+		createRegistry := func(name string, cfg *sdk.FaultConfig) *ModelRegistryReconciler {
+			namespace = &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: name,
+				},
+			}
+			typeNamespaceName = types.NamespacedName{Name: name, Namespace: name}
+
+			err := k8sClient.Create(ctx, namespace)
+			Expect(err).NotTo(HaveOccurred())
+
+			var restPort int32 = 8080
+			var postgresPort int32 = 5432
+			mr := &v1beta1.ModelRegistry{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: name,
+				},
+				Spec: v1beta1.ModelRegistrySpec{
+					Rest: v1beta1.RestSpec{
+						Port: &restPort,
+					},
+					Postgres: &v1beta1.PostgresConfig{
+						Host:     "db.example.com",
+						Port:     &postgresPort,
+						Database: "model_registry",
+						Username: "admin",
+						PasswordSecret: &v1beta1.SecretKeyValue{
+							Name: name + "-db-secret",
+							Key:  "password",
+						},
+					},
+				},
+			}
+
+			dbSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name + "-db-secret",
+					Namespace: name,
+				},
+				StringData: map[string]string{
+					"password": "test-password",
+				},
+			}
+			err = k8sClient.Create(ctx, dbSecret)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = k8sClient.Create(ctx, mr)
+			Expect(err).NotTo(HaveOccurred())
+
+			return initChaosReconciler(chaosTemplate, cfg)
+		}
+
+		AfterEach(func() {
+			if namespace != nil {
+				found := &v1beta1.ModelRegistry{}
+				err := k8sClient.Get(ctx, typeNamespaceName, found)
+				if err == nil {
+					_ = k8sClient.Delete(ctx, found)
+				}
+				_ = k8sClient.Delete(ctx, namespace)
+			}
+			_ = os.Unsetenv(config.RestImage)
+			_ = os.Unsetenv(config.PostgresImage)
+			_ = os.Unsetenv(config.KubeRBACProxyImage)
+		})
+
+		It("should handle Get errors with requeue", func() {
+			cfg := sdk.NewFaultConfig(map[sdk.Operation]sdk.FaultSpec{
+				sdk.OpGet: {ErrorRate: 1.0, Error: "chaos: connection refused"},
+			})
+
+			reconciler := createRegistry("chaos-get-errors", cfg)
+
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespaceName,
+			})
+
+			Expect(err).To(HaveOccurred(), "expected a chaos error on Get")
+			var chaosErr *sdk.ChaosError
+			Expect(errors.As(err, &chaosErr)).To(BeTrue(), "error should be a ChaosError")
+			Expect(chaosErr.Operation).To(Equal(sdk.OpGet))
+		})
+
+		It("should converge after transient Get errors clear", func() {
+			cfg := sdk.NewFaultConfig(map[sdk.Operation]sdk.FaultSpec{
+				sdk.OpGet: {ErrorRate: 1.0, Error: "chaos: transient connection refused"},
+			})
+
+			reconciler := createRegistry("chaos-get-transient", cfg)
+
+			By("Verifying reconciler fails while faults are active")
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespaceName,
+			})
+			Expect(err).To(HaveOccurred())
+
+			By("Clearing faults and verifying convergence")
+			cfg.Deactivate()
+
+			Eventually(func() error {
+				_, err := reconciler.Reconcile(ctx, reconcile.Request{
+					NamespacedName: typeNamespaceName,
+				})
+				return err
+			}, 30*time.Second, 500*time.Millisecond).Should(Succeed(),
+				"reconciler should converge once Get errors stop")
+		})
+
+		It("should remain converged when Update faults are present but no drift exists", func() {
+			reconciler := createRegistry("chaos-update-no-drift", nil)
+
+			By("Running initial clean reconcile to create resources")
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespaceName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Injecting Update faults and verifying reconciler stays healthy (no updates needed)")
+			cfg := sdk.NewFaultConfig(map[sdk.Operation]sdk.FaultSpec{
+				sdk.OpUpdate: {ErrorRate: 1.0, Error: "chaos: the object has been modified"},
+			})
+			reconciler.Client = sdk.NewChaosClient(k8sClient, cfg)
+
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespaceName,
+			})
+			Expect(err).NotTo(HaveOccurred(),
+				"reconciler should succeed when state is converged and no updates are needed")
+		})
+
+		It("should handle Create failures and report errors", func() {
+			cfg := sdk.NewFaultConfig(map[sdk.Operation]sdk.FaultSpec{
+				sdk.OpCreate: {ErrorRate: 1.0, Error: "chaos: quota exceeded"},
+			})
+
+			reconciler := createRegistry("chaos-create-fail", cfg)
+
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespaceName,
+			})
+
+			Expect(err).To(HaveOccurred(), "reconciler should return error when all Creates fail")
+
+			var chaosErr *sdk.ChaosError
+			Expect(errors.As(err, &chaosErr)).To(BeTrue(), "error should be a ChaosError")
+			Expect(chaosErr.Operation).To(Equal(sdk.OpCreate))
+		})
+
+		It("should converge after transient Create failures clear", func() {
+			cfg := sdk.NewFaultConfig(map[sdk.Operation]sdk.FaultSpec{
+				sdk.OpCreate: {ErrorRate: 1.0, Error: "chaos: quota exceeded"},
+			})
+
+			reconciler := createRegistry("chaos-create-transient", cfg)
+
+			By("Verifying reconciler fails while faults are active")
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespaceName,
+			})
+			Expect(err).To(HaveOccurred())
+
+			By("Clearing faults and verifying convergence")
+			cfg.Deactivate()
+
+			Eventually(func() error {
+				_, err := reconciler.Reconcile(ctx, reconcile.Request{
+					NamespacedName: typeNamespaceName,
+				})
+				return err
+			}, 30*time.Second, 500*time.Millisecond).Should(Succeed(),
+				"reconciler should converge once Create failures stop")
+		})
+
+		It("should tolerate intermittent API errors and eventually converge", func() {
+			cfg := sdk.NewFaultConfig(map[sdk.Operation]sdk.FaultSpec{
+				sdk.OpGet:    {ErrorRate: 0.15, Error: "chaos: intermittent timeout"},
+				sdk.OpCreate: {ErrorRate: 0.15, Error: "chaos: intermittent quota exceeded"},
+			})
+
+			reconciler := createRegistry("chaos-intermittent", cfg)
+
+			Eventually(func() error {
+				_, err := reconciler.Reconcile(ctx, reconcile.Request{
+					NamespacedName: typeNamespaceName,
+				})
+				return err
+			}, 30*time.Second, 200*time.Millisecond).Should(Succeed(),
+				"reconciler should eventually converge despite intermittent errors")
+		})
+	})
+})
+
+var _ = Describe("ModelCatalog chaos resilience", func() {
+
+	ctx := context.Background()
+
+	var chaosTemplate *template.Template
+
+	BeforeEach(func() {
+		err := os.Setenv(config.RestImage, config.DefaultRestImage)
+		Expect(err).NotTo(HaveOccurred())
+		err = os.Setenv(config.PostgresImage, config.DefaultPostgresImage)
+		Expect(err).NotTo(HaveOccurred())
+		err = os.Setenv(config.CatalogDataImage, config.DefaultCatalogDataImage)
+		Expect(err).NotTo(HaveOccurred())
+		err = os.Setenv(config.BenchmarkDataImage, config.DefaultBenchmarkDataImage)
+		Expect(err).NotTo(HaveOccurred())
+		config.SetDefaultDomain("example.com", nil, false)
+
+		var parseErr error
+		chaosTemplate, parseErr = config.ParseTemplates()
+		Expect(parseErr).NotTo(HaveOccurred())
+	})
+
+	Describe("catalog reconciler under API faults", func() {
+
+		var (
+			namespace     *corev1.Namespace
+			namespaceName string
+		)
+
+		createCatalogNamespace := func(suffix string) string {
+			namespaceName = fmt.Sprintf("chaos-catalog-%s-%d", suffix, time.Now().UnixNano())
+			namespace = &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      namespaceName,
+					Namespace: namespaceName,
+				},
+			}
+			err := k8sClient.Create(ctx, namespace)
+			Expect(err).NotTo(HaveOccurred())
+			return namespaceName
+		}
+
+		AfterEach(func() {
+			if namespace != nil {
+				_ = k8sClient.Delete(ctx, namespace)
+			}
+			crb := &rbac.ClusterRoleBinding{}
+			crbName := modelCatalogName + "-auth-delegator"
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: crbName}, crb); err == nil {
+				_ = k8sClient.Delete(ctx, crb)
+			}
+			_ = os.Unsetenv(config.RestImage)
+			_ = os.Unsetenv(config.PostgresImage)
+			_ = os.Unsetenv(config.CatalogDataImage)
+			_ = os.Unsetenv(config.BenchmarkDataImage)
+		})
+
+		It("should handle Get errors with chaos error", func() {
+			ns := createCatalogNamespace("get-errors")
+			cfg := sdk.NewFaultConfig(map[sdk.Operation]sdk.FaultSpec{
+				sdk.OpGet: {ErrorRate: 1.0, Error: "chaos: connection refused"},
+			})
+
+			reconciler := initCatalogChaosReconciler(chaosTemplate, cfg, ns)
+
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: modelCatalogName, Namespace: ns},
+			})
+
+			Expect(err).To(HaveOccurred())
+			var chaosErr *sdk.ChaosError
+			Expect(errors.As(err, &chaosErr)).To(BeTrue(), "error should be a ChaosError")
+		})
+
+		It("should converge after transient Get errors clear", func() {
+			ns := createCatalogNamespace("get-transient")
+			cfg := sdk.NewFaultConfig(map[sdk.Operation]sdk.FaultSpec{
+				sdk.OpGet: {ErrorRate: 1.0, Error: "chaos: transient connection refused"},
+			})
+
+			reconciler := initCatalogChaosReconciler(chaosTemplate, cfg, ns)
+
+			By("Verifying reconciler fails while faults are active")
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: modelCatalogName, Namespace: ns},
+			})
+			Expect(err).To(HaveOccurred())
+
+			By("Clearing faults and verifying convergence")
+			cfg.Deactivate()
+
+			Eventually(func() error {
+				_, err := reconciler.Reconcile(ctx, reconcile.Request{
+					NamespacedName: types.NamespacedName{Name: modelCatalogName, Namespace: ns},
+				})
+				return err
+			}, 30*time.Second, 500*time.Millisecond).Should(Succeed(),
+				"catalog reconciler should converge once Get errors stop")
+		})
+
+		It("should handle Create failures during resource provisioning", func() {
+			ns := createCatalogNamespace("create-fail")
+			cfg := sdk.NewFaultConfig(map[sdk.Operation]sdk.FaultSpec{
+				sdk.OpCreate: {ErrorRate: 1.0, Error: "chaos: quota exceeded"},
+			})
+
+			reconciler := initCatalogChaosReconciler(chaosTemplate, cfg, ns)
+
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: modelCatalogName, Namespace: ns},
+			})
+
+			Expect(err).To(HaveOccurred(), "catalog reconciler should return error when all Creates fail")
+
+			var chaosErr *sdk.ChaosError
+			Expect(errors.As(err, &chaosErr)).To(BeTrue(), "error should be a ChaosError")
+			Expect(chaosErr.Operation).To(Equal(sdk.OpCreate))
+		})
+
+		It("should converge after transient Create failures clear and verify resources exist", func() {
+			ns := createCatalogNamespace("create-transient")
+			cfg := sdk.NewFaultConfig(map[sdk.Operation]sdk.FaultSpec{
+				sdk.OpCreate: {ErrorRate: 1.0, Error: "chaos: quota exceeded"},
+			})
+
+			reconciler := initCatalogChaosReconciler(chaosTemplate, cfg, ns)
+
+			By("Verifying reconciler fails while faults are active")
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: modelCatalogName, Namespace: ns},
+			})
+			Expect(err).To(HaveOccurred())
+
+			By("Clearing faults and verifying convergence")
+			cfg.Deactivate()
+
+			Eventually(func() error {
+				_, err := reconciler.Reconcile(ctx, reconcile.Request{
+					NamespacedName: types.NamespacedName{Name: modelCatalogName, Namespace: ns},
+				})
+				return err
+			}, 30*time.Second, 500*time.Millisecond).Should(Succeed(),
+				"catalog reconciler should converge once Create failures stop")
+
+			By("Verifying catalog deployment was created")
+			deploy := &appsv1.Deployment{}
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: modelCatalogName, Namespace: ns}, deploy)
+			Expect(err).NotTo(HaveOccurred(), "catalog deployment should exist after convergence")
+
+			By("Verifying catalog service account was created")
+			sa := &corev1.ServiceAccount{}
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: modelCatalogName, Namespace: ns}, sa)
+			Expect(err).NotTo(HaveOccurred(), "catalog service account should exist after convergence")
+		})
+	})
+})


### PR DESCRIPTION
## Description
Integrate operator-chaos SDK into model-registry-operator to enable shift-left chaos validation across L1 through L3 maturity levels:

- L1 Breaking Change Detection: CI workflow validates knowledge model and experiment definitions against operator schema changes
- L2 Experiment/Knowledge Validation: knowledge model describing operator components, managed resources, webhooks, finalizers, and steady-state checks; 9 chaos experiment definitions covering pod-kill, network-partition, webhook-disrupt, config-drift, rbac-revoke, finalizer-block, catalog-pod-kill, and catalog-config-drift scenarios
- L3 Chaos Test Execution: ChaosClient SDK tests for ModelRegistry and ModelCatalog reconcilers with 10 Ginkgo specs exercising fault injection, recovery validation, and steady-state assertions

Adds CI workflow (chaos-validate.yml), Makefile targets (test-chaos, chaos-validate, operator-chaos install), and operator-chaos Go dependency.

## How Has This Been Tested?
This essentially adds new tests and CI to run the chaos testing functionality

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a suite of chaos experiments to exercise resilience of the model-registry and model-catalog components.
  * Added a knowledge configuration describing expected components, resources, and steady-state checks.

* **Tests**
  * Added a comprehensive chaos resilience test suite validating controller behavior and recovery under injected faults.

* **Chores**
  * Added CI workflow and Makefile targets to validate chaos manifests and run chaos-focused tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->