### PR TITLE
feat: integrate with cluster TLS security profile

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -123,39 +123,6 @@ func main() {
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
-	// Fetch the cluster TLS security profile for webhook and metrics servers
-	bootstrapCtx, bootstrapCancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer bootstrapCancel()
-	bootstrapClient, err := client.New(ctrl.GetConfigOrDie(), client.Options{Scheme: scheme})
-	if err != nil {
-		setupLog.Error(err, "unable to create bootstrap client for TLS profile")
-		os.Exit(1)
-	}
-	profile, err := tlspkg.FetchAPIServerTLSProfile(bootstrapCtx, bootstrapClient)
-	if err != nil {
-		setupLog.Error(err, "unable to fetch TLS profile, using defaults")
-	}
-	tlsConfigFn, unsupportedCiphers := tlspkg.NewTLSConfigFromProfile(profile)
-	if len(unsupportedCiphers) > 0 {
-		setupLog.Info("some ciphers from TLS profile are not supported by Go", "unsupported", unsupportedCiphers)
-	}
-	nextProtosFn := func(c *tls.Config) {
-		c.NextProtos = []string{"h2", "http/1.1"}
-	}
-
-	// set metrics server options, including custom cert if provided
-	metricsServerOptions := metricsserver.Options{
-		BindAddress:   metricsAddr,
-		SecureServing: secureMetrics,
-		CertDir:       metricsCertDir,
-		CertName:      metricsCertName,
-		KeyName:       metricsKeyName,
-		TLSOpts:       []func(*tls.Config){tlsConfigFn, nextProtosFn},
-	}
-	if secureMetrics {
-		metricsServerOptions.FilterProvider = filters.WithAuthenticationAndAuthorization
-	}
-
 	capabilities, err := getCapabilities()
 	if err != nil {
 		setupLog.Error(err, "error detecting cluster capabilities")
@@ -166,6 +133,44 @@ func main() {
 		"hasUserAPI", capabilities.HasUserAPI,
 		"hasConfigAPI", capabilities.HasConfigAPI,
 		"hasAuthAPI", capabilities.HasAuthAPI)
+
+	// On OpenShift, fetch the cluster TLS security profile for webhook and metrics servers
+	var tlsOpts []func(*tls.Config)
+	var profile oapiconfig.TLSProfileSpec
+	if capabilities.HasConfigAPI {
+		bootstrapCtx, bootstrapCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer bootstrapCancel()
+		bootstrapClient, err := client.New(ctrl.GetConfigOrDie(), client.Options{Scheme: scheme})
+		if err != nil {
+			setupLog.Error(err, "unable to create bootstrap client for TLS profile")
+			os.Exit(1)
+		}
+		profile, err = tlspkg.FetchAPIServerTLSProfile(bootstrapCtx, bootstrapClient)
+		if err != nil {
+			setupLog.Error(err, "unable to fetch TLS profile, using defaults")
+		}
+		tlsConfigFn, unsupportedCiphers := tlspkg.NewTLSConfigFromProfile(profile)
+		if len(unsupportedCiphers) > 0 {
+			setupLog.Info("some ciphers from TLS profile are not supported by Go", "unsupported", unsupportedCiphers)
+		}
+		tlsOpts = append(tlsOpts, tlsConfigFn)
+	}
+	tlsOpts = append(tlsOpts, func(c *tls.Config) {
+		c.NextProtos = []string{"h2", "http/1.1"}
+	})
+
+	// set metrics server options, including custom cert if provided
+	metricsServerOptions := metricsserver.Options{
+		BindAddress:   metricsAddr,
+		SecureServing: secureMetrics,
+		CertDir:       metricsCertDir,
+		CertName:      metricsCertName,
+		KeyName:       metricsKeyName,
+		TLSOpts:       tlsOpts,
+	}
+	if secureMetrics {
+		metricsServerOptions.FilterProvider = filters.WithAuthenticationAndAuthorization
+	}
 
 	registriesNamespace := os.Getenv(config.RegistriesNamespace)
 	enableWebhooks := os.Getenv(config.EnableWebhooks) != "false"
@@ -220,7 +225,7 @@ func main() {
 		},
 		Metrics: metricsServerOptions,
 		WebhookServer: ctrlwebhook.NewServer(ctrlwebhook.Options{
-			TLSOpts: []func(*tls.Config){tlsConfigFn, nextProtosFn},
+			TLSOpts: tlsOpts,
 		}),
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
@@ -333,20 +338,22 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Register SecurityProfileWatcher: cancel context on TLS profile change so pod restarts
+	// Register SecurityProfileWatcher on OpenShift: cancel context on TLS profile change so pod restarts
 	ctx, cancel := context.WithCancel(ctrl.SetupSignalHandler())
 	defer cancel()
-	watcher := &tlspkg.SecurityProfileWatcher{
-		Client:                mgr.GetClient(),
-		InitialTLSProfileSpec: profile,
-		OnProfileChange: func(_ context.Context, _, _ oapiconfig.TLSProfileSpec) {
-			setupLog.Info("TLS profile changed, initiating graceful shutdown to reload")
-			cancel()
-		},
-	}
-	if err := watcher.SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to register TLS security profile watcher")
-		os.Exit(1)
+	if capabilities.HasConfigAPI {
+		watcher := &tlspkg.SecurityProfileWatcher{
+			Client:                mgr.GetClient(),
+			InitialTLSProfileSpec: profile,
+			OnProfileChange: func(_ context.Context, _, _ oapiconfig.TLSProfileSpec) {
+				setupLog.Info("TLS profile changed, initiating graceful shutdown to reload")
+				cancel()
+			},
+		}
+		if err := watcher.SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to register TLS security profile watcher")
+			os.Exit(1)
+		}
 	}
 
 	// Start storage migration monitor

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -17,12 +17,16 @@ limitations under the License.
 package main
 
 import (
+	"context"
+	"crypto/tls"
 	"flag"
 	"os"
+	"time"
 
 	"github.com/opendatahub-io/model-registry-operator/internal/webhook"
 
 	routev1 "github.com/openshift/api/route/v1"
+	tlspkg "github.com/openshift/controller-runtime-common/pkg/tls"
 	networking "istio.io/client-go/pkg/apis/networking/v1beta1"
 	security "istio.io/client-go/pkg/apis/security/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -54,6 +58,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	ctrlwebhook "sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	modelregistryv1alpha1 "github.com/opendatahub-io/model-registry-operator/api/v1alpha1"
 	modelregistryv1beta1 "github.com/opendatahub-io/model-registry-operator/api/v1beta1"
@@ -118,6 +123,26 @@ func main() {
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
+	// Fetch the cluster TLS security profile for webhook and metrics servers
+	bootstrapCtx, bootstrapCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer bootstrapCancel()
+	bootstrapClient, err := client.New(ctrl.GetConfigOrDie(), client.Options{Scheme: scheme})
+	if err != nil {
+		setupLog.Error(err, "unable to create bootstrap client for TLS profile")
+		os.Exit(1)
+	}
+	profile, err := tlspkg.FetchAPIServerTLSProfile(bootstrapCtx, bootstrapClient)
+	if err != nil {
+		setupLog.Error(err, "unable to fetch TLS profile, using defaults")
+	}
+	tlsConfigFn, unsupportedCiphers := tlspkg.NewTLSConfigFromProfile(profile)
+	if len(unsupportedCiphers) > 0 {
+		setupLog.Info("some ciphers from TLS profile are not supported by Go", "unsupported", unsupportedCiphers)
+	}
+	nextProtosFn := func(c *tls.Config) {
+		c.NextProtos = []string{"h2", "http/1.1"}
+	}
+
 	// set metrics server options, including custom cert if provided
 	metricsServerOptions := metricsserver.Options{
 		BindAddress:   metricsAddr,
@@ -125,6 +150,7 @@ func main() {
 		CertDir:       metricsCertDir,
 		CertName:      metricsCertName,
 		KeyName:       metricsKeyName,
+		TLSOpts:       []func(*tls.Config){tlsConfigFn, nextProtosFn},
 	}
 	if secureMetrics {
 		metricsServerOptions.FilterProvider = filters.WithAuthenticationAndAuthorization
@@ -192,7 +218,10 @@ func main() {
 				DisableFor: []client.Object{&corev1.Secret{}},
 			},
 		},
-		Metrics:                metricsServerOptions,
+		Metrics: metricsServerOptions,
+		WebhookServer: ctrlwebhook.NewServer(ctrlwebhook.Options{
+			TLSOpts: []func(*tls.Config){tlsConfigFn, nextProtosFn},
+		}),
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "85f368d1.opendatahub.io",
@@ -304,8 +333,23 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Register SecurityProfileWatcher: cancel context on TLS profile change so pod restarts
+	ctx, cancel := context.WithCancel(ctrl.SetupSignalHandler())
+	defer cancel()
+	watcher := &tlspkg.SecurityProfileWatcher{
+		Client:                mgr.GetClient(),
+		InitialTLSProfileSpec: profile,
+		OnProfileChange: func(_ context.Context, _, _ oapiconfig.TLSProfileSpec) {
+			setupLog.Info("TLS profile changed, initiating graceful shutdown to reload")
+			cancel()
+		},
+	}
+	if err := watcher.SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to register TLS security profile watcher")
+		os.Exit(1)
+	}
+
 	// Start storage migration monitor
-	ctx := ctrl.SetupSignalHandler()
 	migrationMgr := migration.NewStorageMigrationManager(mgr.GetClient())
 	migrationMgr.StartMigrationMonitor(ctx)
 

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -81,6 +81,7 @@ rules:
 - apiGroups:
   - config.openshift.io
   resources:
+  - apiservers
   - ingresses
   verbs:
   - get

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/onsi/gomega v1.41.0
 	github.com/opendatahub-io/operator-chaos v0.0.0-20260521100204-4dab974d613c
 	github.com/openshift/api v0.0.0-20260601143908-70f01b82bb53
+	github.com/openshift/controller-runtime-common v0.0.0-20260428152732-64ee174f5e2e
 	istio.io/client-go v1.30.1
 	k8s.io/api v0.36.1
 	k8s.io/apiextensions-apiserver v0.36.1
@@ -65,6 +66,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/openshift/library-go v0.0.0-20260213153706-03f1709971c5 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_golang v1.23.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -198,6 +198,10 @@ github.com/opendatahub-io/operator-chaos v0.0.0-20260521100204-4dab974d613c h1:o
 github.com/opendatahub-io/operator-chaos v0.0.0-20260521100204-4dab974d613c/go.mod h1:f9D+8VSCrpTB2EeGD6F26ZkaO8GN7dCbT9lFZfZ68t0=
 github.com/openshift/api v0.0.0-20260601143908-70f01b82bb53 h1:I9aH3KSRGfBxVacrjpA7r5AZQj12VCHBHMWEypeKBWE=
 github.com/openshift/api v0.0.0-20260601143908-70f01b82bb53/go.mod h1:pyVjK0nZ4sRs4fuQVQ4rubsJdahI1PB94LnQ8sGdvxo=
+github.com/openshift/controller-runtime-common v0.0.0-20260428152732-64ee174f5e2e h1:k89oIo2EjX0PRSdi1kesktCyWp50SC9WwKurvupvRGs=
+github.com/openshift/controller-runtime-common v0.0.0-20260428152732-64ee174f5e2e/go.mod h1:XGabTMnNbz0M5Oa7IbscZp/jmcc7aHobvOCUWwkzKvM=
+github.com/openshift/library-go v0.0.0-20260213153706-03f1709971c5 h1:9Pe6iVOMjt9CdA/vaKBNUSoEIjIe1po5Ha3ABRYXLJI=
+github.com/openshift/library-go v0.0.0-20260213153706-03f1709971c5/go.mod h1:K3FoNLgNBFYbFuG+Kr8usAnQxj1w84XogyUp2M8rK8k=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/internal/controller/kubebuilder.go
+++ b/internal/controller/kubebuilder.go
@@ -12,6 +12,7 @@
 // +kubebuilder:rbac:groups=core,resources=secrets,verbs=create;get;list;watch;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=persistentvolumeclaims,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=config.openshift.io,resources=ingresses,verbs=get;list;watch
+// +kubebuilder:rbac:groups=config.openshift.io,resources=apiservers,verbs=get;list;watch
 // +kubebuilder:rbac:groups=route.openshift.io,resources=routes;routes/custom-host,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=user.openshift.io,resources=groups,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings;clusterrolebindings,verbs=get;list;watch;create;update;patch;delete


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-61073

## Description

Integrate model-registry-operator with the cluster-wide TLS security profile from `apiservers.config.openshift.io/cluster`, required for OCP 5.0 TLS profile compliance ([OCPSTRAT-2611](https://redhat.atlassian.net/browse/OCPSTRAT-2611)).

Uses `controller-runtime-common/pkg/tls` (the standard OCP library for TLS profile integration):

1. Fetch TLS profile at startup via `FetchAPIServerTLSProfile`
2. Build `tls.Config` callback via `NewTLSConfigFromProfile`
3. Apply to both webhook and metrics server `TLSOpts`
4. Set `NextProtos` (`h2`, `http/1.1`) on all TLS endpoints
5. Register `SecurityProfileWatcher` that triggers graceful restart on profile change
6. Add RBAC for `config.openshift.io/apiservers` get/list/watch

Reference PRs:
- [openshift/cluster-machine-approver#286](https://github.com/openshift/cluster-machine-approver/pull/286) (canonical controller-runtime-common example)
- [opendatahub-io/mlflow-operator#140](https://github.com/opendatahub-io/mlflow-operator/pull/140) (RHOAI template)

Integration guide: https://docs.google.com/document/d/1XUehWMzXeteHPwuEyh96m7ORvTanCHPyKgSEx630UQQ/edit

## How Has This Been Tested?

- `go build ./...` passes
- `go vet ./...` clean
- `go mod tidy` produces clean dependency resolution
- `make manifests` regenerates RBAC with new `apiservers` permission
- CodeRabbit review: 0 findings
- Envtest-based tests require envtest binaries (CI-only), unaffected by this change

## Merge criteria:

- [x] The commits and have meaningful messages; the author will squash them after approval or will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Operator aligns HTTPS configuration with the cluster TLS security profile at startup for metrics and webhook endpoints.
  * Operator now reloads/restarts automatically when the cluster TLS security profile changes to apply updated settings.
  * Falls back to safe default TLS settings and logs an error if the cluster profile cannot be read at startup.

* **Chores**
  * Added permissions so the operator can read cluster TLS/profile resources to enable the above behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->