### PR TITLE
fix(catalog): use HTTP /readyz probe instead of TCP socket for readiness

### DIFF
--- a/internal/controller/config/defaults_test.go
+++ b/internal/controller/config/defaults_test.go
@@ -530,18 +530,19 @@ func TestCatalogDeployment(t *testing.T) {
 
 		hasProxyEndpointsPort := false
 		for _, arg := range kubeRBACProxyContainer.Args {
-			if strings.HasPrefix(arg, "--proxy-endpoints-port=") {
+			if arg == "--proxy-endpoints-port=8888" {
 				hasProxyEndpointsPort = true
 			}
 		}
 		if !hasProxyEndpointsPort {
-			t.Errorf("kube-rbac-proxy should have --proxy-endpoints-port argument for unauthenticated health checks")
+			t.Errorf("kube-rbac-proxy should set --proxy-endpoints-port=8888 for unauthenticated health checks")
 		}
 
 		if kubeRBACProxyContainer.ReadinessProbe == nil ||
 			kubeRBACProxyContainer.ReadinessProbe.HTTPGet == nil ||
-			kubeRBACProxyContainer.ReadinessProbe.HTTPGet.Port.StrVal != "proxy-healthz" {
-			t.Errorf("kube-rbac-proxy readiness probe should target the proxy-healthz port")
+			kubeRBACProxyContainer.ReadinessProbe.HTTPGet.Port.StrVal != "proxy-healthz" ||
+			kubeRBACProxyContainer.ReadinessProbe.HTTPGet.Path != "/healthz" {
+			t.Errorf("kube-rbac-proxy readiness probe should target /healthz on proxy-healthz")
 		}
 	})
 }

--- a/internal/controller/config/defaults_test.go
+++ b/internal/controller/config/defaults_test.go
@@ -527,6 +527,22 @@ func TestCatalogDeployment(t *testing.T) {
 		if !hasUpstream {
 			t.Errorf("kube-rbac-proxy should have --upstream argument")
 		}
+
+		hasProxyEndpointsPort := false
+		for _, arg := range kubeRBACProxyContainer.Args {
+			if strings.HasPrefix(arg, "--proxy-endpoints-port=") {
+				hasProxyEndpointsPort = true
+			}
+		}
+		if !hasProxyEndpointsPort {
+			t.Errorf("kube-rbac-proxy should have --proxy-endpoints-port argument for unauthenticated health checks")
+		}
+
+		if kubeRBACProxyContainer.ReadinessProbe == nil ||
+			kubeRBACProxyContainer.ReadinessProbe.HTTPGet == nil ||
+			kubeRBACProxyContainer.ReadinessProbe.HTTPGet.Port.StrVal != "proxy-healthz" {
+			t.Errorf("kube-rbac-proxy readiness probe should target the proxy-healthz port")
+		}
 	})
 }
 

--- a/internal/controller/config/templates/catalog/catalog-deployment.yaml.tmpl
+++ b/internal/controller/config/templates/catalog/catalog-deployment.yaml.tmpl
@@ -117,8 +117,10 @@ spec:
           readinessProbe:
             initialDelaySeconds: 3
             periodSeconds: 5
-            tcpSocket:
+            httpGet:
+              path: /readyz
               port: http-api
+              scheme: HTTP
             timeoutSeconds: 2
           {{- with .Spec.Rest.Resources }}
           resources:

--- a/internal/controller/modelcatalog_controller_test.go
+++ b/internal/controller/modelcatalog_controller_test.go
@@ -141,6 +141,7 @@ var _ = Describe("ModelCatalog controller", func() {
 				Expect(proxyContainer.Args).To(ContainElement("--secure-listen-address=0.0.0.0:8443"))
 				Expect(proxyContainer.Args).To(ContainElement("--upstream=http://127.0.0.1:8080/"))
 				Expect(proxyContainer.Args).To(ContainElement("--config-file=/etc/kube-rbac-proxy/config-file.yaml"))
+				Expect(proxyContainer.Args).To(ContainElement("--proxy-endpoints-port=8888"))
 
 				// Check that oauth-proxy specific args are NOT present
 				for _, arg := range proxyContainer.Args {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

# Model Catalog: Connection Refused After Pod Restart

## Issue

After a model-catalog pod is deleted and recreated (e.g., to pick up a ConfigMap change), the external route returns `ConnectionRefusedError` for approximately 30 seconds. The pod is marked Ready by Kubernetes, but clients hitting the route get connection failures.

Reported in CI on GCP clusters running RHOAI 3.5.0-ea.2.

## Root Cause

Two factors combine to produce this bug:

### 1. Upstream readiness change (the trigger)

A recent change in the model-registry server (kubeflow/hub) altered the startup sequence. The server now binds port 8080 **before** plugins are fully initialized, and exposes a `/readyz` endpoint to signal actual readiness:

```json
{"plugins":{"mcp":true,"model":true},"status":"ready"}
```

The operator's readiness probe was a **TCP socket check** on port 8080. This probe passes the instant the port opens — before the server is ready to serve. The pod is marked Ready prematurely.

### 2. GCP cross-node GENEVE latency (the amplifier)

On GCP clusters using OVN-Kubernetes, cross-node traffic traverses GENEVE tunnels (MTU 1360). When the pod is marked Ready too early, HAProxy's dynamic server update fires and both router pods attempt TLS connections to the kube-rbac-proxy sidecar. On GCP, the cross-node router's initial TLS handshakes fail:

```
http: TLS handshake error from <router-ip>: write tcp <pod-ip>:8443-><router-ip>: write: connection reset by peer
```

These early failed connections leave HAProxy in a state where client requests routed through the cross-node router get `ConnectionRefusedError` until the connections recover.

This does **not** reproduce on ROSA/AWS or OSP — their network fabric completes OVN flow programming fast enough that even the premature Ready doesn't cause failures.

## Fix

Switch the catalog container's readiness probe from TCP socket to HTTP `/readyz`:

```diff
  readinessProbe:
-   tcpSocket:
-     port: http-api
+   httpGet:
+     path: /readyz
+     port: http-api
+     scheme: HTTP
    initialDelaySeconds: 3
    periodSeconds: 5
    timeoutSeconds: 2
```

This delays the pod's Ready transition until the server reports actual readiness via `/readyz`. The additional seconds allow OVN flows to propagate and HAProxy to establish healthy connections before client traffic is routed.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Verification

Tested on GCP cluster `mr-gcp-02` (OCP 4.21, OVN-Kubernetes, GENEVE MTU 1360). Operators scaled down to prevent reconciliation during testing.

### Before fix (TCP socket probe)

| Metric | Result |
|--------|--------|
| Client failures after pod Ready | **1** (`http=000` timeout) |
| TLS handshake errors | **150+**, persistent for 15+ minutes |
| Error pattern | Every ~5s from cross-node router, never stops |

### After fix (HTTP /readyz probe)

| Metric | Result |
|--------|--------|
| Client failures after pod Ready | **0** |
| TLS handshake errors | 50–70 (background HAProxy health check noise) |
| Error pattern | Does not affect client traffic |

### Jira reproduction steps (after fix)

Following the exact steps from the Jira:

1. Updated `model-catalog-sources` ConfigMap with two catalog sources
2. Deleted the model-catalog pod
3. Waited for the new pod to be marked Ready (took ~10 seconds)
4. Immediately sent requests to the external route

```
Pod first Ready:       17:47:10 (attempt #7)
First 200 after Ready: 17:47:12
Failures after Ready:  0
```

5 additional back-to-back restart cycles confirmed: **0 client failures across all rounds**.

### What the fix does NOT address

The kube-rbac-proxy logs still show TLS handshake errors from the cross-node router on GCP. These are HAProxy health check probes failing through the GENEVE overlay — a GCP OVN infrastructure behavior, not a model-catalog bug. They do not affect client traffic:

- HAProxy reports `L6OK` (health check passing) and `ssl_failed_handshake: 0`
- All client requests return HTTP 200 after pod Ready
- The errors exist on GCP regardless of the readiness probe configuration

### Cross-platform results

| Cluster | Platform | TCP probe (before) | /readyz probe (after) |
|---------|----------|-------------------|----------------------|
| `caas-aprag-4914` | ROSA / AWS | 0 errors, no issue | N/A |
| `mr-smoke2` | OSP | 0 errors, no issue | N/A |
| `mr-gcp-02` | GCP | 150+ errors, client failures | 0 client failures |


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Strengthened validation of proxy startup arguments and health-check behavior.

* **Chores**
  * Changed catalog readiness probe from a TCP socket to an HTTP GET /readyz for more reliable health checks.
  * Ensured the proxy exposes a dedicated endpoints port for unauthenticated health probes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->